### PR TITLE
justin/encryption_safety: Add exception handling to decryption + tiny Auto-Login fixes

### DIFF
--- a/app/src/main/java/com/appdev/eateryblueandroid/ui/components/profile/Main.kt
+++ b/app/src/main/java/com/appdev/eateryblueandroid/ui/components/profile/Main.kt
@@ -2,6 +2,7 @@ package com.appdev.eateryblueandroid.ui.components.profile
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -19,7 +20,8 @@ fun Main(
     accountFilter: AccountType,
     transactionQuery: String,
     updateQuery: (updatedQuery: String) -> Unit,
-    showBottomSheet: () -> Unit
+    showBottomSheet: () -> Unit,
+    lazyListState : LazyListState
 ) {
     var displayQuery by remember { mutableStateOf(transactionQuery) }
     val transactionHistoryList = user.transactions?.filter {
@@ -40,7 +42,8 @@ fun Main(
     ).flatten()
 
     LazyColumn(
-        contentPadding = PaddingValues(bottom = 100.dp)
+        contentPadding = PaddingValues(bottom = 100.dp),
+        state = lazyListState
     ) {
         items(profileItems) { item ->
             when (item) {

--- a/app/src/main/java/com/appdev/eateryblueandroid/ui/navigation/ProfileTabController.kt
+++ b/app/src/main/java/com/appdev/eateryblueandroid/ui/navigation/ProfileTabController.kt
@@ -4,34 +4,26 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import com.appdev.eateryblueandroid.ui.screens.settings.*
-import com.appdev.eateryblueandroid.ui.viewmodels.*
-import com.appdev.eateryblueandroid.util.*
+import com.appdev.eateryblueandroid.ui.viewmodels.BottomSheetViewModel
+import com.appdev.eateryblueandroid.ui.viewmodels.EateryDetailViewModel
+import com.appdev.eateryblueandroid.ui.viewmodels.HomeViewModel
+import com.appdev.eateryblueandroid.ui.viewmodels.ProfileViewModel
 
 @Composable
 fun ProfileTabController(
     profileViewModel: ProfileViewModel,
     bottomSheetViewModel: BottomSheetViewModel,
     eateryState: State<HomeViewModel.State>,
-    profileEateryDetailViewModel : EateryDetailViewModel
+    profileEateryDetailViewModel: EateryDetailViewModel
 ) {
     val display = profileViewModel.display.collectAsState()
-    val cached = LoginRepository.loginFlow.collectAsState()
 
     display.value.let {
         when (it) {
-            is ProfileViewModel.Display.Login -> {
-                if (cached.value.ready()) {
-                    ProfileScreen(
-                        profileViewModel = profileViewModel,
-                        bottomSheetViewModel = bottomSheetViewModel
-                    )
-                } else {
-                    LoginScreen(
-                        profileViewModel = profileViewModel
-                    )
-                }
-
-            }
+            is ProfileViewModel.Display.Login ->
+                LoginScreen(
+                    profileViewModel = profileViewModel
+                )
             is ProfileViewModel.Display.Profile ->
                 ProfileScreen(
                     profileViewModel = profileViewModel,

--- a/app/src/main/java/com/appdev/eateryblueandroid/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/appdev/eateryblueandroid/ui/screens/ProfileScreen.kt
@@ -3,6 +3,7 @@ package com.appdev.eateryblueandroid.ui.screens
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.ripple.rememberRipple
@@ -85,7 +86,7 @@ fun ProfileScreen(
             }
         }
 
-
+        val lazyListState = rememberLazyListState()
         state.value.let {
             when (it) {
                 is ProfileViewModel.State.ProfileData -> {
@@ -94,7 +95,8 @@ fun ProfileScreen(
                         accountFilter = it.accountFilter,
                         transactionQuery = it.query,
                         updateQuery = profileViewModel::updateQuery,
-                        showBottomSheet = showBottomSheet
+                        showBottomSheet = showBottomSheet,
+                        lazyListState = lazyListState
                     )
                 }
                 is ProfileViewModel.State.AutoLoggingIn -> {
@@ -103,7 +105,8 @@ fun ProfileScreen(
                         accountFilter = it.cachedProfileData.accountFilter,
                         transactionQuery = it.cachedProfileData.query,
                         updateQuery = profileViewModel::updateQuery,
-                        showBottomSheet = showBottomSheet
+                        showBottomSheet = showBottomSheet,
+                        lazyListState = lazyListState
                     )
                 }
                 is ProfileViewModel.State.LoginFailure ->

--- a/app/src/main/java/com/appdev/eateryblueandroid/ui/viewmodels/ProfileViewModel.kt
+++ b/app/src/main/java/com/appdev/eateryblueandroid/ui/viewmodels/ProfileViewModel.kt
@@ -1,5 +1,6 @@
 package com.appdev.eateryblueandroid.ui.viewmodels
 
+import android.util.Log
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.IntOffset
@@ -70,8 +71,16 @@ class ProfileViewModel : ViewModel() {
     fun watchForAutoLogin() {
         CoroutineScope(Dispatchers.IO).launch {
             LoginRepository.loginFlow.collect { state ->
-                if (state.ready()) {
-                    autoLogin(state.username, decryptData(passwordAlias, state.encryptedPassword))
+                try {
+                    if (state.ready()) {
+                        autoLogin(
+                            state.username,
+                            decryptData(passwordAlias, state.encryptedPassword)
+                        )
+                    }
+                }
+                catch (e: Exception) {
+                    Log.e("AutoLoginFailure", e.message ?: "Login Failed.")
                 }
             }
         }

--- a/app/src/main/java/com/appdev/eateryblueandroid/ui/viewmodels/ProfileViewModel.kt
+++ b/app/src/main/java/com/appdev/eateryblueandroid/ui/viewmodels/ProfileViewModel.kt
@@ -1,22 +1,21 @@
 package com.appdev.eateryblueandroid.ui.viewmodels
 
 import android.util.Log
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.appdev.eateryblueandroid.R
 import com.appdev.eateryblueandroid.models.AccountType
 import com.appdev.eateryblueandroid.models.User
 import com.appdev.eateryblueandroid.networking.get.GetApiService
 import com.appdev.eateryblueandroid.util.Constants.passwordAlias
 import com.appdev.eateryblueandroid.util.LoginRepository
 import com.appdev.eateryblueandroid.util.decryptData
-import com.appdev.eateryblueandroid.util.overrideStatusBarColor
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import java.util.*
 
 class ProfileViewModel : ViewModel() {
@@ -78,9 +77,8 @@ class ProfileViewModel : ViewModel() {
                             decryptData(passwordAlias, state.encryptedPassword)
                         )
                     }
-                }
-                catch (e: Exception) {
-                    Log.e("AutoLoginFailure", e.message ?: "Login Failed.")
+                } catch (e: Exception) {
+                    Log.e("AutoLoginFailure", e.stackTraceToString())
                 }
             }
         }
@@ -92,11 +90,12 @@ class ProfileViewModel : ViewModel() {
             password,
             State.ProfileData(LoginRepository.makeCachedUser(), "", AccountType.MEALSWIPES)
         )
-        _display.value = Display.Login(authenticating = true, progress = 0.3f)
+        _display.value = Display.Profile
     }
 
     fun webpageLoaded() {
-        _display.value = Display.Login(authenticating = true, progress = 0.6f)
+        if (state.value !is State.AutoLoggingIn)
+            _display.value = Display.Login(authenticating = true, progress = 0.6f)
     }
 
     fun transitionSettings() {

--- a/app/src/main/java/com/appdev/eateryblueandroid/util/Encryption.kt
+++ b/app/src/main/java/com/appdev/eateryblueandroid/util/Encryption.kt
@@ -4,7 +4,6 @@ import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
 import android.util.Log
-import java.io.ByteArrayInputStream
 import java.security.KeyStore
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
@@ -12,17 +11,21 @@ import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 
 private val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-private val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+private val keyGenerator =
+    KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
 private val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
 
 private val utf8 by lazy {
     Charsets.UTF_8
 }
 
-private fun makeSecretKey(alias : String) : SecretKey {
+private fun makeSecretKey(alias: String): SecretKey {
     return keyGenerator.apply {
         init(
-            KeyGenParameterSpec.Builder(alias, KeyProperties.PURPOSE_DECRYPT or KeyProperties.PURPOSE_ENCRYPT)
+            KeyGenParameterSpec.Builder(
+                alias,
+                KeyProperties.PURPOSE_DECRYPT or KeyProperties.PURPOSE_ENCRYPT
+            )
                 .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                 .build()
@@ -31,25 +34,25 @@ private fun makeSecretKey(alias : String) : SecretKey {
 
 }
 
-private fun getSecretKey(alias : String) = (keyStore.getEntry(alias, null) as KeyStore.SecretKeyEntry).secretKey
+private fun getSecretKey(alias: String) =
+    (keyStore.getEntry(alias, null) as KeyStore.SecretKeyEntry).secretKey
 
-fun encryptData(alias : String, data : String): String {
+fun encryptData(alias: String, data: String): String {
     cipher.init(Cipher.ENCRYPT_MODE, makeSecretKey(alias))
     Log.i("CipherTest", "My IV: " + String(cipher.iv, utf8))
     // Encodes the data to string, then returns.
-    return Base64.encodeToString(cipher.iv, Base64.NO_WRAP) + "||" + Base64.encodeToString(cipher.doFinal(data.toByteArray(utf8)), Base64.NO_WRAP)
+    return Base64.encodeToString(
+        cipher.iv,
+        Base64.NO_WRAP
+    ) + "||" + Base64.encodeToString(cipher.doFinal(data.toByteArray(utf8)), Base64.NO_WRAP)
 }
 
-fun decryptData(alias : String, data : String) : String {
+fun decryptData(alias: String, data: String): String {
     // Takes in data, gets the IV as a ByteArray.
-    //Log.i("CipherTest", data)
-
     val ivString = Base64.decode(data.substring(0, data.indexOf("||")), Base64.NO_WRAP)
-    //Log.i("CipherTest", "Grabbed IV: " + String(ivString, utf8))
 
     // Get the actually encrypted part as a ByteArray.
-    val encryptedData = Base64.decode(data.substring(data.indexOf("||")+2), Base64.NO_WRAP)
-    //Log.i("CipherTest", encryptedData)
+    val encryptedData = Base64.decode(data.substring(data.indexOf("||") + 2), Base64.NO_WRAP)
 
     cipher.init(Cipher.DECRYPT_MODE, getSecretKey(alias), GCMParameterSpec(128, ivString))
     return cipher.doFinal(encryptedData).toString(utf8)


### PR DESCRIPTION
Very small PR to handle a rare (and irreproducible) issue with encrypting and decrypting data. Currently, if a bad encryption is saved to local storage, the app just continually crashes and locks the user out every time the app is opened. This PR should fix this, making it so that if a bad encryption is saved, the user can simply log in again and save a correct encryption.

**Changes:**
- When decryption fails, app no longer continually crashes. Instead, users are simply prompted to login again.
- Profile scroll no longer jumps back to top when auto login succeeds + causes recomposition.
- Auto Login refactored to interact w/ profileViewModel Display as intended. 