### PR TITLE
Hide wait times

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/EateryDetailScreen.kt
@@ -341,54 +341,54 @@ fun EateryDetailScreen(
                                     .width(1.dp)
                             )
 
-                            Column(
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                                modifier = Modifier
-                                    .padding(vertical = 12.dp)
-                                    .weight(1f, true)
-                            ) {
-                                Row(
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    modifier = Modifier.clickable {
-                                        sheetContent = BottomSheetContent.WAIT_TIME
-                                        coroutineScope.launch {
-                                            modalBottomSheetState.show()
-                                        }
-                                    }
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Default.HourglassTop,
-                                        contentDescription = "Watch Icon",
-                                        tint = GrayFive
-                                    )
-                                    Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
-                                    Text(
-                                        text = "Wait Time",
-                                        style = TextStyle(
-                                            fontWeight = FontWeight.SemiBold,
-                                            fontSize = 16.sp
-                                        ),
-                                        color = GrayFive
-                                    )
-                                }
-
-                                val waitTimes = eatery.getWaitTimes()
-                                Text(
-                                    modifier = Modifier.padding(top = 2.dp),
-                                    text = if (!waitTimes.isNullOrEmpty() && !eatery.isClosed()) {
-                                        "$waitTimes minutes"
-                                    } else {
-                                        "-"
-                                    },
-                                    style = TextStyle(
-                                        fontWeight = FontWeight.SemiBold,
-                                        fontSize = 16.sp
-                                    ),
-                                    color = Color.Black,
-                                )
-
-
-                            }
+//                            Column(
+//                                horizontalAlignment = Alignment.CenterHorizontally,
+//                                modifier = Modifier
+//                                    .padding(vertical = 12.dp)
+//                                    .weight(1f, true)
+//                            ) {
+//                                Row(
+//                                    verticalAlignment = Alignment.CenterVertically,
+//                                    modifier = Modifier.clickable {
+//                                        sheetContent = BottomSheetContent.WAIT_TIME
+//                                        coroutineScope.launch {
+//                                            modalBottomSheetState.show()
+//                                        }
+//                                    }
+//                                ) {
+//                                    Icon(
+//                                        imageVector = Icons.Default.HourglassTop,
+//                                        contentDescription = "Watch Icon",
+//                                        tint = GrayFive
+//                                    )
+//                                    Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
+//                                    Text(
+//                                        text = "Wait Time",
+//                                        style = TextStyle(
+//                                            fontWeight = FontWeight.SemiBold,
+//                                            fontSize = 16.sp
+//                                        ),
+//                                        color = GrayFive
+//                                    )
+//                                }
+//
+//                                val waitTimes = eatery.getWaitTimes()
+//                                Text(
+//                                    modifier = Modifier.padding(top = 2.dp),
+//                                    text = if (!waitTimes.isNullOrEmpty() && !eatery.isClosed()) {
+//                                        "$waitTimes minutes"
+//                                    } else {
+//                                        "-"
+//                                    },
+//                                    style = TextStyle(
+//                                        fontWeight = FontWeight.SemiBold,
+//                                        fontSize = 16.sp
+//                                    ),
+//                                    color = Color.Black,
+//                                )
+//
+//
+//                            }
                         }
 
                         Spacer(


### PR DESCRIPTION
**Overview**
Hide wait times widget on individual Eatery screen

**Changes Made**
• commented out the Column containing wait-times icon in EateryDetailScreen

**Test Coverage**
I manually tested it

**Screenshots**
<img width="372" alt="Screenshot 2023-09-17 at 12 51 00 PM" src="https://github.com/cuappdev/eatery-blue-android/assets/69655767/319655a3-d534-41c4-9586-cb49251eb888">
