### PR TITLE
Fix nearest first favorite bug & dependency issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,9 @@ plugins {
     id 'com.google.dagger.hilt.android'
 }
 
+android.buildFeatures.buildConfig true
+
+
 def secretsPropertiesFile = rootProject.file('secrets.properties')
 def secretsProperties = new Properties()
 secretsProperties.load(new FileInputStream(secretsPropertiesFile))

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/HomeScreen.kt
@@ -436,10 +436,14 @@ fun HomeScreen(
                                             items(homeViewModel.nearestEateries) { eatery ->
                                                 EateryCard(
                                                     eatery = eatery,
-                                                    isFavorite = false,
+                                                    isFavorite = homeViewModel.favoriteEateries.any { favoriteEatery ->
+                                                        favoriteEatery.id == eatery.id
+                                                    },
                                                     modifier = Modifier.fillParentMaxWidth(0.85f),
                                                     onFavoriteClick = {
-                                                        if (!it) {
+                                                        if (it) {
+                                                            homeViewModel.addFavorite(eatery.id)
+                                                        } else {
                                                             homeViewModel.removeFavorite(eatery.id)
                                                         }
                                                     }) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Sep 25 01:25:16 EDT 2022
+#Sun Sep 24 12:12:00 EDT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
**Overview**
Users can now favorite their nearest eateries.

**Changes**
- Added favorite eateries logic to nearest first scrolling list
- Added 'android.buildFeatures.buildConfig true' to app build.gradle file

**Testing**
I manually tested it.

**Screenshots/Videos
[nearestfirstfavbug.webm](https://github.com/cuappdev/eatery-blue-android/assets/69655767/4cb10150-d416-4a37-9249-5f659ca1ea0b)

**