### PR TITLE
Fix Proceed to Eatery Button

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/components/onboarding/OnboardingCarousel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/components/onboarding/OnboardingCarousel.kt
@@ -5,7 +5,14 @@ import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
@@ -136,8 +143,8 @@ fun OnboardingCarousel(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .padding(
-                                        start = 48.dp,
-                                        end = 48.dp,
+                                        start = .1f.dp,
+                                        end = .1f.dp,
                                         bottom = 32.dp,
                                         top = 24.dp
                                     )


### PR DESCRIPTION
**Overview**
"Proceed to Eatery" text getting cut off on onboarding screen

**Changes**
- Changed fixed padding to fraction so it adjusts for each device

**Testing**
I manually tested it.

**Screenshots**
Before:
<img width="376" alt="proceedbefore" src="https://github.com/cuappdev/eatery-blue-android/assets/69655767/b54bcaaf-235d-48a0-a596-8eb6bb86c7ac">

After:
<img width="461" alt="proceedafter" src="https://github.com/cuappdev/eatery-blue-android/assets/69655767/4e50e212-e19b-43e9-8545-5009fc7831ba">

