### PR TITLE
Justin/loading patch

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eateryblue/data/repositories/EateryRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/data/repositories/EateryRepository.kt
@@ -114,8 +114,15 @@ class EateryRepository @Inject constructor(private val networkApi: NetworkApi) {
 
     /**
      * Returns the [State] representing the API call for the specified eatery.
+     * If ALL eateries are already loaded, then this simply instantly returns that.
      */
     fun getEateryState(eateryId: Int) : State<EateryApiResponse<Eatery>> {
+        if (eateryFlow.value is EateryApiResponse.Success) {
+            return mutableStateOf(EateryApiResponse.Success(
+                (eateryFlow.value as EateryApiResponse.Success<List<Eatery>>)
+                    .data.find {it.id == eateryId}!!))
+        }
+
         // If not called yet or is in an error, re-ping.
         if (!eateryApiCache.contains(eateryId)
             || eateryApiCache[eateryId]!!.value is EateryApiResponse.Error) {

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/data/repositories/EateryRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/data/repositories/EateryRepository.kt
@@ -19,16 +19,16 @@ import javax.inject.Singleton
 
 @Singleton
 class EateryRepository @Inject constructor(private val networkApi: NetworkApi) {
-    suspend fun getAllEateries(): List<Eatery> =
+    private suspend fun getAllEateries(): List<Eatery> =
         networkApi.fetchEateries()
 
-    suspend fun getEatery(eateryId: Int): Eatery =
+    private suspend fun getEatery(eateryId: Int): Eatery =
         networkApi.fetchEatery(eateryId = eateryId.toString())
 
-    suspend fun getHomeEateries(): List<Eatery> =
+    private suspend fun getHomeEateries(): List<Eatery> =
         networkApi.fetchHomeEateries()
 
-    suspend fun getAllEvents(): ApiResponse<List<Event>> =
+    private suspend fun getAllEvents(): ApiResponse<List<Event>> =
         networkApi.fetchEvents()
 
     private val _eateryFlow: MutableStateFlow<EateryApiResponse<List<Eatery>>> =
@@ -115,7 +115,7 @@ class EateryRepository @Inject constructor(private val networkApi: NetworkApi) {
     /**
      * Returns the [State] representing the API call for the specified eatery.
      */
-    fun getEateryFlow(eateryId: Int) : State<EateryApiResponse<Eatery>> {
+    fun getEateryState(eateryId: Int) : State<EateryApiResponse<Eatery>> {
         // If not called yet or is in an error, re-ping.
         if (!eateryApiCache.contains(eateryId)
             || eateryApiCache[eateryId]!!.value is EateryApiResponse.Error) {

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/FavoritesScreen.kt
@@ -1,6 +1,5 @@
 package com.cornellappdev.android.eateryblue.ui.screens
 
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,7 +18,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -38,7 +37,7 @@ import com.cornellappdev.android.eateryblue.ui.theme.EateryBlue
 import com.cornellappdev.android.eateryblue.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eateryblue.ui.theme.GrayTwo
 import com.cornellappdev.android.eateryblue.ui.viewmodels.FavoritesViewModel
-import com.cornellappdev.android.eateryblue.ui.viewmodels.state.EateryRetrievalState
+import com.cornellappdev.android.eateryblue.ui.viewmodels.state.EateryApiResponse
 import com.valentinilk.shimmer.ShimmerBounds
 import com.valentinilk.shimmer.rememberShimmer
 import com.valentinilk.shimmer.shimmer
@@ -49,11 +48,7 @@ fun FavoritesScreen(
     onEateryClick: (eatery: Eatery) -> Unit
 ) {
     val shimmer = rememberShimmer(ShimmerBounds.View)
-
-    LaunchedEffect(Unit) {
-        Log.i("favorites", "balhlakbakjlkrga")
-        favoriteViewModel.queryFavoriteEateries()
-    }
+    val favoriteEateriesApiResponse = favoriteViewModel.favoriteEateries.collectAsState().value
 
     Column(
         modifier = Modifier
@@ -71,8 +66,8 @@ fun FavoritesScreen(
 
         // TODO add filtering
 
-        when (favoriteViewModel.eateryRetrievalState) {
-            is EateryRetrievalState.Pending -> {
+        when (favoriteEateriesApiResponse) {
+            is EateryApiResponse.Pending -> {
                 LazyColumn(
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
@@ -86,12 +81,13 @@ fun FavoritesScreen(
                 }
             }
 
-            is EateryRetrievalState.Error -> {
+            is EateryApiResponse.Error -> {
                 // TODO Add No Internet/Oopsie display
             }
 
-            is EateryRetrievalState.Success -> {
-                if (favoriteViewModel.favoriteEateries.isEmpty()) {
+            is EateryApiResponse.Success -> {
+                val favoriteEateries = favoriteEateriesApiResponse.data
+                if (favoriteEateries.isEmpty()) {
                     Box(
                         modifier = Modifier
                             .fillMaxHeight(0.7f)
@@ -128,7 +124,7 @@ fun FavoritesScreen(
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
                         items(
-                            items = favoriteViewModel.favoriteEateries.distinct(),
+                            items = favoriteEateries,
                             key = { eatery ->
                                 eatery.id!!
                             }) { eatery ->

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/HomeScreen.kt
@@ -94,6 +94,7 @@ fun HomeScreen(
     val eateriesApiResponse = homeViewModel.eateryFlow.collectAsState().value
     val filters = homeViewModel.filtersFlow.collectAsState().value
     val nearestEateries = homeViewModel.nearestEateries.collectAsState().value
+    val favorites = homeViewModel.favoriteEateries.collectAsState().value
 
     // Here a DisposableEffect is launched when the bottom sheet opens. 
     // When it disappears it's from the view hierarchy, which will cause
@@ -328,7 +329,7 @@ fun HomeScreen(
                                         ) {
                                             EateryCard(
                                                 eatery = eatery,
-                                                isFavorite = homeViewModel.favoriteEateries.any { favoriteEatery ->
+                                                isFavorite = favorites.any { favoriteEatery ->
                                                     favoriteEatery.id == eatery.id
                                                 },
                                                 onFavoriteClick = {
@@ -395,7 +396,7 @@ fun HomeScreen(
                                         }
 
                                         LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                                            items(homeViewModel.favoriteEateries) { eatery ->
+                                            items(favorites) { eatery ->
                                                 EateryCard(
                                                     eatery = eatery,
                                                     isFavorite = true,
@@ -438,7 +439,7 @@ fun HomeScreen(
                                             items(nearestEateries) { eatery ->
                                                 EateryCard(
                                                     eatery = eatery,
-                                                    isFavorite = homeViewModel.favoriteEateries.any { favoriteEatery ->
+                                                    isFavorite = favorites.any { favoriteEatery ->
                                                         favoriteEatery.id == eatery.id
                                                     },
                                                     modifier = Modifier.fillParentMaxWidth(0.85f),
@@ -488,7 +489,7 @@ fun HomeScreen(
                                             items(swipeEateries) { eatery ->
                                                 EateryCard(
                                                     eatery = eatery,
-                                                    isFavorite = homeViewModel.favoriteEateries.any { favoriteEatery ->
+                                                    isFavorite = favorites.any { favoriteEatery ->
                                                         favoriteEatery.id == eatery.id
                                                     },
                                                     modifier = Modifier.fillParentMaxWidth(0.85f),
@@ -533,7 +534,7 @@ fun HomeScreen(
                                     ) {
                                         EateryCard(
                                             eatery = eatery,
-                                            isFavorite = homeViewModel.favoriteEateries.any { favoriteEatery ->
+                                            isFavorite = favorites.any { favoriteEatery ->
                                                 favoriteEatery.id == eatery.id
                                             },
                                             onFavoriteClick = {

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/HomeScreen.kt
@@ -36,8 +36,8 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
@@ -67,7 +67,7 @@ import com.cornellappdev.android.eateryblue.ui.theme.EateryBlue
 import com.cornellappdev.android.eateryblue.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eateryblue.ui.theme.GrayZero
 import com.cornellappdev.android.eateryblue.ui.viewmodels.HomeViewModel
-import com.cornellappdev.android.eateryblue.ui.viewmodels.state.EateryRetrievalState
+import com.cornellappdev.android.eateryblue.ui.viewmodels.state.EateryApiResponse
 import com.valentinilk.shimmer.ShimmerBounds
 import com.valentinilk.shimmer.rememberShimmer
 import kotlinx.coroutines.launch
@@ -91,10 +91,9 @@ fun HomeScreen(
     val coroutineScope = rememberCoroutineScope()
     val shimmer = rememberShimmer(ShimmerBounds.View)
 
-    // Refreshes the favorites when this view appears everytime.
-    LaunchedEffect(Unit) {
-        homeViewModel.updateFavorites()
-    }
+    val eateriesApiResponse = homeViewModel.eateryFlow.collectAsState().value
+    val filters = homeViewModel.filtersFlow.collectAsState().value
+    val nearestEateries = homeViewModel.nearestEateries.collectAsState().value
 
     // Here a DisposableEffect is launched when the bottom sheet opens. 
     // When it disappears it's from the view hierarchy, which will cause
@@ -253,7 +252,9 @@ fun HomeScreen(
                                             top = 24.dp
                                         )
                                     ) {
-                                        AnimatedVisibility(visible = homeViewModel.eateryRetrievalState is EateryRetrievalState.Success) {
+                                        AnimatedVisibility(
+                                            visible = eateriesApiResponse is EateryApiResponse.Success
+                                        ) {
                                             Icon(
                                                 painter = painterResource(id = R.drawable.ic_eaterylogo),
                                                 contentDescription = null,
@@ -271,18 +272,20 @@ fun HomeScreen(
                         }
                     }
 
-                    when (homeViewModel.eateryRetrievalState) {
-                        is EateryRetrievalState.Pending -> {
+                    when (eateriesApiResponse) {
+                        is EateryApiResponse.Pending -> {
                             items(MainLoadingItem.mainItems) { item ->
                                 CreateMainLoadingItem(item, shimmer)
                             }
                         }
 
-                        is EateryRetrievalState.Error -> {
+                        is EateryApiResponse.Error -> {
                             // TODO Add No Internet/Oopsie display
                         }
 
-                        is EateryRetrievalState.Success -> {
+                        is EateryApiResponse.Success -> {
+                            val eateries = eateriesApiResponse.data
+
                             item {
                                 SearchBar(
                                     searchText = "",
@@ -299,14 +302,14 @@ fun HomeScreen(
 
                                 FilterRow(
                                     modifier = Modifier.padding(start = 16.dp),
-                                    currentFiltersSelected = homeViewModel.currentFiltersSelected,
+                                    currentFiltersSelected = filters,
                                     onPaymentMethodsClicked = {
                                         coroutineScope.launch {
                                             modalBottomSheetState.show()
                                         }
                                     },
                                     onFilterClicked = { filter ->
-                                        if (homeViewModel.currentFiltersSelected.contains(filter)) {
+                                        if (filters.contains(filter)) {
                                             homeViewModel.removeFilter(filter)
                                         } else {
                                             homeViewModel.addFilter(filter)
@@ -314,9 +317,9 @@ fun HomeScreen(
                                     })
                             }
 
-                            if (homeViewModel.currentFiltersSelected.isNotEmpty()) {
-                                if (homeViewModel.filteredResults.isNotEmpty()) {
-                                    itemsIndexed(homeViewModel.filteredResults) { index, eatery ->
+                            if (filters.isNotEmpty()) {
+                                if (eateries.isNotEmpty()) {
+                                    items(eateries) { eatery ->
                                         Box(
                                             Modifier.padding(
                                                 horizontal = 16.dp,
@@ -432,8 +435,7 @@ fun HomeScreen(
                                             )
                                         }
                                         LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                                            homeViewModel.updateNearest()
-                                            items(homeViewModel.nearestEateries) { eatery ->
+                                            items(nearestEateries) { eatery ->
                                                 EateryCard(
                                                     eatery = eatery,
                                                     isFavorite = homeViewModel.favoriteEateries.any { favoriteEatery ->
@@ -460,7 +462,7 @@ fun HomeScreen(
 
                                 item {
                                     val swipeEateries =
-                                        homeViewModel.allEateries.filter { eatery ->
+                                        eateries.filter { eatery ->
                                             eatery.paymentAcceptsMealSwipes == true
                                         }
 
@@ -519,7 +521,7 @@ fun HomeScreen(
                                 }
 
                                 itemsIndexed(
-                                    homeViewModel.allEateries.toList()
+                                    eateries
                                 ) { index, eatery ->
                                     Box(
                                         Modifier.padding(
@@ -547,8 +549,6 @@ fun HomeScreen(
                                 }
                             }
                         }
-
-                        else -> {}
                     }
                 }
             })

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/EateryDetailViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/EateryDetailViewModel.kt
@@ -12,14 +12,7 @@ import com.cornellappdev.android.eateryblue.data.repositories.EateryRepository
 import com.cornellappdev.android.eateryblue.data.repositories.UserPreferencesRepository
 import com.cornellappdev.android.eateryblue.data.repositories.UserRepository
 import com.cornellappdev.android.eateryblue.ui.viewmodels.state.EateryApiResponse
-import com.cornellappdev.android.eateryblue.ui.viewmodels.state.EateryRetrievalState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -42,10 +35,13 @@ class EateryDetailViewModel @Inject constructor(
     }
 
     fun openEatery(eateryId: Int) {
-        eatery = eateryRepository.getEateryFlow(eateryId)
+        // Technically, this isn't using the Flow architecture correctly, but it's safe to assume
+        //  this will work since this screen is only accessible after eatery info is loaded.
+        eatery = eateryRepository.getEateryState(eateryId)
+        isFavorite = userPreferencesRepository.favoritesFlow.value[eateryId] == true
     }
 
-    fun toggleFavorite() = viewModelScope.launch {
+    fun toggleFavorite() {
         userPreferencesRepository.setFavorite(eateryId, !isFavorite)
         isFavorite = !isFavorite
     }

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/HomeViewModel.kt
@@ -29,6 +29,10 @@ class HomeViewModel @Inject constructor(
     private val eateryRepository: EateryRepository
 ) : ViewModel() {
     private val _filtersFlow: MutableStateFlow<List<Filter>> = MutableStateFlow(listOf())
+
+    /**
+     * A flow of filters applied to the screen.
+     */
     val filtersFlow = _filtersFlow.asStateFlow()
 
     /**

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/HomeViewModel.kt
@@ -84,7 +84,10 @@ class HomeViewModel @Inject constructor(
             is EateryApiResponse.Error -> listOf()
             is EateryApiResponse.Pending -> listOf()
             is EateryApiResponse.Success -> {
-                apiResponse.data.sortedBy { it.getWalkTimes() }.slice(0..5)
+                apiResponse.data.sortedBy { it.getWalkTimes() }.let{ nearestSorted ->
+                    if (nearestSorted.size < 6) nearestSorted
+                    else nearestSorted.slice(0..5)
+                }
             }
         }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, listOf())

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/HomeViewModel.kt
@@ -161,12 +161,12 @@ class HomeViewModel @Inject constructor(
                         (filters.contains(Filter.CASH) && eatery.paymentAcceptsCash == true)))
     }
 
-    fun addFavorite(eateryId: Int?) = viewModelScope.launch {
+    fun addFavorite(eateryId: Int?) {
         if (eateryId != null)
             userPreferencesRepository.setFavorite(eateryId, true)
     }
 
-    fun removeFavorite(eateryId: Int?) = viewModelScope.launch {
+    fun removeFavorite(eateryId: Int?) {
         if (eateryId != null)
             userPreferencesRepository.setFavorite(eateryId, false)
     }

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/HomeViewModel.kt
@@ -31,6 +31,9 @@ class HomeViewModel @Inject constructor(
     private val _filtersFlow: MutableStateFlow<List<Filter>> = MutableStateFlow(listOf())
     val filtersFlow = _filtersFlow.asStateFlow()
 
+    /**
+     * A flow emitting all eateries with the appropriate filters applied.
+     */
     val eateryFlow: StateFlow<EateryApiResponse<List<Eatery>>> =
         eateryRepository.homeEateryFlow.combine(_filtersFlow) { apiResponse, filters ->
             when (apiResponse) {
@@ -49,7 +52,12 @@ class HomeViewModel @Inject constructor(
     var favoriteEateries = mutableStateListOf<Eatery>()
         private set
 
-    var nearestEateries: StateFlow<List<Eatery>> = eateryFlow.map { apiResponse ->
+    /**
+     * A [StateFlow] that emits the 6 nearest eateries based on location.
+     *
+     * TODO: Walk times may not be updating automatically; may have to change location to use state.
+     */
+    val nearestEateries: StateFlow<List<Eatery>> = eateryFlow.map { apiResponse ->
         when (apiResponse) {
             is EateryApiResponse.Error -> listOf()
             is EateryApiResponse.Pending -> listOf()

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/HomeViewModel.kt
@@ -10,12 +10,17 @@ import com.cornellappdev.android.eateryblue.data.models.Eatery
 import com.cornellappdev.android.eateryblue.data.repositories.EateryRepository
 import com.cornellappdev.android.eateryblue.data.repositories.UserPreferencesRepository
 import com.cornellappdev.android.eateryblue.ui.components.general.Filter
-import com.cornellappdev.android.eateryblue.ui.viewmodels.state.EateryRetrievalState
+import com.cornellappdev.android.eateryblue.ui.viewmodels.state.EateryApiResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 
 @HiltViewModel
@@ -23,25 +28,36 @@ class HomeViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val eateryRepository: EateryRepository
 ) : ViewModel() {
-    var eateryRetrievalState: EateryRetrievalState by mutableStateOf(EateryRetrievalState.Pending)
-        private set
+    private val _filtersFlow: MutableStateFlow<List<Filter>> = MutableStateFlow(listOf())
+    val filtersFlow = _filtersFlow.asStateFlow()
 
-    private val _currentFiltersSelected = mutableStateListOf<Filter>()
-    val currentFiltersSelected: List<Filter> = _currentFiltersSelected
+    val eateryFlow: StateFlow<EateryApiResponse<List<Eatery>>> =
+        eateryRepository.homeEateryFlow.combine(_filtersFlow) { apiResponse, filters ->
+            when (apiResponse) {
+                is EateryApiResponse.Error -> EateryApiResponse.Error
+                is EateryApiResponse.Pending -> EateryApiResponse.Pending
+                is EateryApiResponse.Success -> {
+                    EateryApiResponse.Success(
+                        apiResponse.data.filter {
+                            passesFilter(it, filters)
+                        })
+                }
+            }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, EateryApiResponse.Pending)
 
-    private val _allEateries = mutableSetOf<Eatery>()
-    val allEateries: Set<Eatery> = _allEateries
-
-    private val mutex = Mutex()
-
+    // TODO: Favorites
     var favoriteEateries = mutableStateListOf<Eatery>()
         private set
 
-    var nearestEateries = mutableStateListOf<Eatery>()
-        private set
-
-    var filteredResults = mutableStateListOf<Eatery>()
-        private set
+    var nearestEateries: StateFlow<List<Eatery>> = eateryFlow.map { apiResponse ->
+        when (apiResponse) {
+            is EateryApiResponse.Error -> listOf()
+            is EateryApiResponse.Pending -> listOf()
+            is EateryApiResponse.Success -> {
+                apiResponse.data.sortedBy { it.getWalkTimes() }.slice(0..5)
+            }
+        }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, listOf())
 
     private var bigPopUp by mutableStateOf(false)
 
@@ -49,133 +65,76 @@ class HomeViewModel @Inject constructor(
         bigPopUp = bool
     }
 
-    init {
-        queryAllEateries()
-    }
-
-    // TODO: Change to directly read from [EateryRepository]'s `homeEateryFlow`
-    //  Also, combine with the favorites map flow.
-    fun queryAllEateries() = viewModelScope.launch {
-        try {
-            val eateryResponse = eateryRepository.getHomeEateries()
-            _allEateries.addAll(eateryResponse)
-
-            val favoriteEateriesIds =
-                userPreferencesRepository.getFavoritesMap().keys
-            favoriteEateries.addAll(_allEateries.filter {
-                favoriteEateriesIds.contains(it.id)
-            })
-
-            eateryRetrievalState = EateryRetrievalState.Success
-        } catch (e: Exception) {
-            eateryRetrievalState = EateryRetrievalState.Error
-        }
-    }
-
-    fun updateFavorites() = viewModelScope.launch {
-        mutex.withLock {
-            val favoriteEateriesKeys =
-                userPreferencesRepository.getFavoritesMap().keys
-            favoriteEateries = _allEateries.filter {
-                favoriteEateriesKeys.contains(it.id)
-            }.toCollection(mutableStateListOf())
-        }
-    }
-
-    fun updateNearest() = viewModelScope.launch {
-        var eateries = _allEateries.sortedBy { it.getWalkTimes() }
-        nearestEateries = eateries.slice(0..5).toCollection(
-            mutableStateListOf()
-        )
-    }
-
     fun addFilter(filter: Filter) = viewModelScope.launch {
-        _currentFiltersSelected.add(filter)
-        filterEateries()
+        val newList = _filtersFlow.value.toMutableList()
+        newList.add(filter)
+        _filtersFlow.value = newList
     }
 
     fun removeFilter(filter: Filter) = viewModelScope.launch {
-        _currentFiltersSelected.remove(filter)
-        filterEateries()
+        val newList = _filtersFlow.value.toMutableList()
+        newList.remove(filter)
+        _filtersFlow.value = newList
     }
 
     fun addPaymentMethodFilters(filters: List<Filter>) = viewModelScope.launch {
-        _currentFiltersSelected.removeAll(Filter.PAYMENT_METHODS)
-        _currentFiltersSelected.addAll(filters)
-        filterEateries()
+        val newList = _filtersFlow.value.toMutableList()
+        newList.removeAll(Filter.PAYMENT_METHODS)
+        newList.addAll(filters)
+        _filtersFlow.value = newList
     }
 
     fun resetFilters() = viewModelScope.launch {
-        _currentFiltersSelected.clear()
-    }
-
-    private fun filterEateries() = viewModelScope.launch {
-        filteredResults = _allEateries.filter { eatery ->
-            passesFilter(eatery)
-        }.toCollection(mutableStateListOf())
+        _filtersFlow.value = listOf()
     }
 
     /**
      * Determines if the eatery passes the filter inspection based on what's currently selected.
      */
-    private fun passesFilter(eatery: Eatery): Boolean {
+    private fun passesFilter(eatery: Eatery, filters: List<Filter>): Boolean {
         var passesFilter = true
-        if (_currentFiltersSelected.contains(Filter.UNDER_10)) {
+        if (filters.contains(Filter.UNDER_10)) {
             val walkTimes = eatery.getWalkTimes()
             passesFilter = walkTimes != null && walkTimes <= 10
         }
 
-        if (_currentFiltersSelected.contains(Filter.FAVORITES)) {
+        if (filters.contains(Filter.FAVORITES)) {
             passesFilter = favoriteEateries.any {
                 it.id == eatery.id
             }
         }
 
         val allLocationsValid =
-            !_currentFiltersSelected.contains(Filter.NORTH) &&
-                !_currentFiltersSelected.contains(Filter.CENTRAL) &&
-                !_currentFiltersSelected.contains(Filter.WEST)
+            !filters.contains(Filter.NORTH) &&
+                    !filters.contains(Filter.CENTRAL) &&
+                    !filters.contains(Filter.WEST)
 
         // Passes filter if all locations aren't selected (therefore any location is valid, specified by allLocationsValid)
         // or one/multiple are selected and the eatery is located there.
         passesFilter = passesFilter &&
-            (allLocationsValid || ((_currentFiltersSelected.contains(Filter.NORTH) && eatery.campusArea == "North") ||
-                (_currentFiltersSelected.contains(Filter.WEST) && eatery.campusArea == "West") ||
-                (_currentFiltersSelected.contains(Filter.CENTRAL) && eatery.campusArea == "Central")))
+                (allLocationsValid || ((filters.contains(Filter.NORTH) && eatery.campusArea == "North") ||
+                        (filters.contains(Filter.WEST) && eatery.campusArea == "West") ||
+                        (filters.contains(Filter.CENTRAL) && eatery.campusArea == "Central")))
 
         val allPaymentMethodsValid =
-            !_currentFiltersSelected.contains(Filter.CASH) &&
-                !_currentFiltersSelected.contains(Filter.BRB) &&
-                !_currentFiltersSelected.contains(Filter.SWIPES)
+            !filters.contains(Filter.CASH) &&
+                    !filters.contains(Filter.BRB) &&
+                    !filters.contains(Filter.SWIPES)
 
         // Passes filter if all three aren't selected (therefore any payment method is valid, specified by allPaymentMethodsValid)
         // or one/multiple are selected and the eatery takes it.
         return passesFilter &&
-            (allPaymentMethodsValid || ((_currentFiltersSelected.contains(Filter.SWIPES) && eatery.paymentAcceptsMealSwipes == true) ||
-                (_currentFiltersSelected.contains(Filter.BRB) && eatery.paymentAcceptsBrbs == true) ||
-                (_currentFiltersSelected.contains(Filter.CASH) && eatery.paymentAcceptsCash == true)))
+                (allPaymentMethodsValid || ((filters.contains(Filter.SWIPES) && eatery.paymentAcceptsMealSwipes == true) ||
+                        (filters.contains(Filter.BRB) && eatery.paymentAcceptsBrbs == true) ||
+                        (filters.contains(Filter.CASH) && eatery.paymentAcceptsCash == true)))
     }
 
-    // Mutex needed to address different coroutine access
     fun addFavorite(eateryId: Int?) = viewModelScope.launch {
-        if (eateryId == null) return@launch
-        mutex.withLock {
-            userPreferencesRepository.setFavorite(eateryId, true)
-            _allEateries.firstOrNull { eatery ->
-                eatery.id == eateryId
-            }?.let { matchingEatery -> favoriteEateries.add(matchingEatery) }
-        }
+        // TODO: Fix favoriting flow.
     }
 
     fun removeFavorite(eateryId: Int?) = viewModelScope.launch {
-        if (eateryId == null) return@launch
-
-        mutex.withLock {
-            userPreferencesRepository.setFavorite(eateryId, false)
-            favoriteEateries.removeIf { eatery ->
-                eatery.id == eateryId
-            }
-        }
+        // TODO: Fix favoriting flow.
     }
 
     fun getNotificationFlowCompleted() = runBlocking {

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/state/EateryRetrievalState.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/state/EateryRetrievalState.kt
@@ -4,15 +4,6 @@ import com.cornellappdev.android.eateryblue.ui.viewmodels.state.EateryApiRespons
 import com.cornellappdev.android.eateryblue.ui.viewmodels.state.EateryApiResponse.Pending
 import com.cornellappdev.android.eateryblue.ui.viewmodels.state.EateryApiResponse.Success
 
-// TODO: Delete this, and replace it with [EateryApiResponse]. Also, replace all occurrences of this
-//  with a Flow-based networking model. See EateryDetailViewModel for an example of using flow
-//  mapping / combination to best fit with Jetpack Compose.
-sealed class EateryRetrievalState {
-    object Pending : EateryRetrievalState()
-    object Error : EateryRetrievalState()
-    object Success : EateryRetrievalState()
-}
-
 /**
  * Represents the state of an api response fetching data of type [T].
  * Can be: [Pending], which represents the call still loading in, [Error], which represents the


### PR DESCRIPTION
## Overview:

Fixes the rest of the data flow between the VM and Data layers. Restructures everything to use flows and the new `EateryApiResponse` instead of the old `EateryRetrievalState`. Results in cached load times and much more readable, easy-to-work-with code. 

More lines deleted than added, even with documentation! That's what we like to see 😎 

**Note:** This is a really good PR to look at to understand the application & benefit of using flows, namely the `combine(...)` function. Data from multiple sources and of multiple types, like eatery lists and favoriting maps, are channeled together into singular flows with no headache, just using some higher order functions. It's the epitome of a flow application!

## Changes:

- Swaps `UserPreferencesRepository`'s favoriting map to use flows.
- Moves ALL API calls into `EateryRepository` and encapsulates them, ensuring no more bad practices.
- Swaps the following viewmodels and their screens to use flows: `HomeViewModel`, `UpcomingViewModel`, `SearchViewModel`, `FavoritesViewModel`.
- After all eateries are loaded, individual eatery load times are instant.
- Every relevant screen now, in effect, "caches" its data so that no reload is required.

## Demo:
<details>

<summary> Full Demo </summary>

https://github.com/cuappdev/eatery-blue-android/assets/47724806/f9d52c4a-9bd4-4e09-8f50-527b9c9277e0

</details>