### PR TITLE
Fix Login using GET Api

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eateryblue/data/MoshiAdapters.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/data/MoshiAdapters.kt
@@ -62,6 +62,22 @@ class ReportAdapter {
     }
 }
 
+class TransactionDateAdapter {
+    @FromJson
+    fun fromJson(date: String): Date {
+        try {
+            val simpleDate =
+                SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZZZ", Locale.US).parse(date)
+            if (simpleDate != null) {
+                return simpleDate
+            }
+        } catch (e: ParseException) {
+            e.printStackTrace()
+        }
+        return Date(0)
+    }
+}
+
 class DateTimeAdapter {
     @ToJson
     fun toJson(dateTime: LocalDateTime): String {

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/data/NetworkingApi.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/data/NetworkingApi.kt
@@ -6,23 +6,27 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Url
 import java.text.SimpleDateFormat
 import java.time.Duration
 import java.util.*
 
 interface NetworkApi {
-    @POST("user")
+    @POST()
     suspend fun fetchUser(
+        @Url url: String,
         @Body body: GetApiRequestBody<GetApiUserParams>
     ): GetApiResponse<User>
 
-    @POST("commerce")
+    @POST()
     suspend fun fetchAccounts(
+        @Url url: String,
         @Body body: GetApiRequestBody<GetApiAccountsParams>
     ): GetApiResponse<AccountsResponse>
 
-    @POST("commerce")
+    @POST()
     suspend fun fetchTransactionHistory(
+        @Url url: String,
         @Body body: GetApiRequestBody<GetApiTransactionHistoryParams>
     ): GetApiResponse<TransactionsResponse>
 

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/data/models/User.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/data/models/User.kt
@@ -2,7 +2,6 @@ package com.cornellappdev.android.eateryblue.data.models
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import java.time.LocalDateTime
 
 @JsonClass(generateAdapter = true)
 data class User(
@@ -40,8 +39,9 @@ data class Transaction(
     @Json(name = "transactionId") val id: String? = null,
     @Json(name = "amount") val amount: Double? = null,
     @Json(name = "resultingBalance") val resultingBalance: Double? = null,
-    @Json(name = "postedDate") val date: LocalDateTime? = null,
-    @Json(name = "transactionType") val transactionType: TransactionType? = null,
+    @Json(name = "postedDate") val date: String? = null,
+    // make this TransactionType later
+    @Json(name = "transactionType") val transactionType: Int? = null,
     @Json(name = "accountName") val accountType: AccountType? = null,
     @Json(name = "locationName") val location: String? = null,
 )
@@ -66,7 +66,7 @@ enum class AccountType {
 }
 
 enum class TransactionType(val value: Int) {
-    DEPOSIT(3), SPEND(1), NOOP(0);
+    DEPOSIT(3), SPEND(1), NOOP(0), WHAT(2);
 
     companion object {
         fun fromInt(value: Int) = values().first { it.value == value }

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/data/repositories/UserRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/data/repositories/UserRepository.kt
@@ -29,8 +29,10 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
             )
         )
 
+    // TODO change this to use get backend?
     suspend fun getUser(sessionId: String): GetApiResponse<User> =
         networkApi.fetchUser(
+            url = BuildConfig.GET_BACKEND_URL + "user",
             body = GetApiRequestBody(
                 version = "1",
                 method = "retrieve",
@@ -42,6 +44,7 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
 
     suspend fun getAccount(sessionId: String, userId: String): GetApiResponse<AccountsResponse> =
         networkApi.fetchAccounts(
+            url = BuildConfig.GET_BACKEND_URL + "commerce",
             body = GetApiRequestBody(
                 version = "1",
                 method = "retrieveAccountsByUser",
@@ -60,6 +63,7 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
             endDate.toInstant().minus(Duration.ofDays(1460))
         )
     ): GetApiResponse<TransactionsResponse> = networkApi.fetchTransactionHistory(
+        url = BuildConfig.GET_BACKEND_URL + "commerce",
         body = GetApiRequestBody(
             version = "1",
             method = "retrieveTransactionHistory",

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/components/login/LoginPage.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/components/login/LoginPage.kt
@@ -16,181 +16,147 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.zIndex
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.android.eateryblue.BuildConfig
-import com.cornellappdev.android.eateryblue.data.models.User
 import com.cornellappdev.android.eateryblue.ui.components.general.CustomTextField
 import com.cornellappdev.android.eateryblue.ui.theme.EateryBlue
 import com.cornellappdev.android.eateryblue.ui.theme.EateryBlueTypography
+import com.cornellappdev.android.eateryblue.ui.theme.GraySix
 import com.cornellappdev.android.eateryblue.ui.theme.GrayThree
 import com.cornellappdev.android.eateryblue.ui.theme.GrayZero
-import com.cornellappdev.android.eateryblue.ui.viewmodels.LoggedInStatus
-import com.cornellappdev.android.eateryblue.ui.viewmodels.LoginState
 import com.cornellappdev.android.eateryblue.ui.viewmodels.LoginViewModel
 
 @Composable
 fun LoginPage(
-    loginViewModel: LoginViewModel = hiltViewModel(),
-    autoLogin: Boolean = true,
-    onSuccess: (User) -> Unit,
-    onError: () -> Unit,
-    onAutoLoginFail: () -> Unit = {},
+    loginState: LoginViewModel.State.Login,
+    loginViewModel: LoginViewModel,
     onWrongCredentials: () -> Unit = {}
 ) {
     val passwordFocus = remember { FocusRequester() }
     val focusManager = LocalFocusManager.current
-    val context = LocalContext.current
-    var netId by rememberSaveable { mutableStateOf("") }
-    var password by rememberSaveable { mutableStateOf("") }
-    var attemptSignIn by rememberSaveable { mutableStateOf(false) }
-    val clickable = netId.isNotEmpty() && password.isNotEmpty() && !attemptSignIn
-    var tryCacheLogin by rememberSaveable { mutableStateOf(autoLogin) }
+    val clickable =
+        loginState.netid.isNotEmpty() && loginState.password.isNotEmpty() && !loginState.loading
 
-    // TODO test cache log in
-    // Tries to login using credentials that's stored locally.
-    if (tryCacheLogin) {
-        when (loginViewModel.isLoggedIn) {
-            LoggedInStatus.Pending -> {
+    Column(modifier = Modifier.zIndex(1f)) {
+        Text(
+            text = "Log in with Eatery",
+            style = EateryBlueTypography.h3,
+            color = EateryBlue
+        )
 
+        Text(
+            text = "See your meal swipes, BRBs, and more",
+            style = TextStyle(fontWeight = FontWeight.Medium, fontSize = 18.sp),
+            color = GraySix,
+            modifier = Modifier.padding(top = 7.dp)
+        )
+        Text(
+            text = "NetID",
+            style = EateryBlueTypography.h5,
+            color = Color.Black,
+            modifier = Modifier.padding(top = 24.dp, bottom = 12.dp)
+        )
+
+        CustomTextField(
+            value = loginState.netid,
+            onValueChange = {
+                loginViewModel.onNetIDTyped(it)
+            },
+            enabled = !loginState.loading,
+            placeholder = "Type your NetID (e.g. abc123)",
+            backgroundColor = GrayZero,
+            onSubmit = {
+                if (loginState.netid.isNotEmpty()) passwordFocus.requestFocus()
             }
+        )
 
-            LoggedInStatus.NotLoggedIn -> {
-                onAutoLoginFail()
-                tryCacheLogin = false
-            }
+        Text(
+            text = "Password",
+            style = EateryBlueTypography.h5,
+            color = Color.Black,
+            modifier = Modifier.padding(top = 24.dp, bottom = 12.dp)
+        )
 
-            is LoggedInStatus.IsLoggedIn -> {
-                val loginInfo = loginViewModel.isLoggedIn as LoggedInStatus.IsLoggedIn
-                netId = loginInfo.username
-                password = loginInfo.password
-
-                // Will activate the LoginWebView
-                attemptSignIn = true
-            }
-        }
-    } else {
-        Column(modifier = Modifier.zIndex(1f)) {
-            Text(
-                text = "NetID",
-                style = EateryBlueTypography.h5,
-                color = Color.Black,
-                modifier = Modifier.padding(top = 24.dp, bottom = 12.dp)
-            )
-
-            CustomTextField(
-                value = netId,
-                onValueChange = {
-                    netId = it
-                },
-                enabled = !attemptSignIn,
-                placeholder = "Type your NetID (e.g. abc123)",
-                backgroundColor = GrayZero,
-                onSubmit = {
-                    if (netId.isNotEmpty()) passwordFocus.requestFocus()
-                }
-            )
-
-            Text(
-                text = "Password",
-                style = EateryBlueTypography.h5,
-                color = Color.Black,
-                modifier = Modifier.padding(top = 24.dp, bottom = 12.dp)
-            )
-
-            CustomTextField(
-                value = password,
-                onValueChange = {
-                    password = it
-                },
-                enabled = !attemptSignIn,
-                placeholder = "Type your password...",
-                backgroundColor = GrayZero,
-                focusRequester = passwordFocus,
-                isPassword = true,
-                onSubmit = {
-                    if (password.isNotEmpty()) {
-                        focusManager.clearFocus()
-                    }
-                }
-            )
-
-            Button(
-                enabled = clickable,
-                shape = RoundedCornerShape(24.dp),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 66.dp)
-                    .height(56.dp),
-                onClick = {
+        CustomTextField(
+            value = loginState.password,
+            onValueChange = {
+                loginViewModel.onPasswordTyped(it)
+            },
+            enabled = !loginState.loading,
+            placeholder = "Type your password...",
+            backgroundColor = GrayZero,
+            focusRequester = passwordFocus,
+            isPassword = true,
+            onSubmit = {
+                if (loginState.password.isNotEmpty()) {
                     focusManager.clearFocus()
-                    attemptSignIn = true
-                },
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = if (clickable) EateryBlue else GrayZero
-                ),
-                elevation = ButtonDefaults.elevation(defaultElevation = 0.dp)
-            ) {
-                Text(
-                    text = if (attemptSignIn) "Logging in..." else "Log in",
-                    color = if (clickable) Color.White else GrayThree,
-                    style = EateryBlueTypography.h5
-                )
+                }
             }
-        }
+        )
 
-        if (attemptSignIn) {
-            // LoginWebView should take up no space whatsoever. User should not be able to see it.
-            Box(
-                modifier = Modifier
-                    .size(0.dp)
-                    .zIndex(-2f)
-            ) {
-                LoginWebView(netId = netId, password = password, onSuccess = { sessionId ->
+        Button(
+            enabled = clickable,
+            shape = RoundedCornerShape(24.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 66.dp)
+                .height(56.dp),
+            onClick = {
+                focusManager.clearFocus()
+                loginViewModel.onLoginPressed()
+            },
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = if (clickable) EateryBlue else GrayZero
+            ),
+            elevation = ButtonDefaults.elevation(defaultElevation = 0.dp)
+        ) {
+            Text(
+                text = if (loginState.loading) "Logging in..." else "Log in",
+                color = if (clickable) Color.White else GrayThree,
+                style = EateryBlueTypography.h5
+            )
+        }
+    }
+
+    if (loginState.loading) {
+        // LoginWebView should take up no space whatsoever. User should not be able to see it.
+        Box(
+            modifier = Modifier
+                .size(0.dp)
+                .zIndex(-2f)
+        ) {
+            LoginWebView(
+                netId = loginState.netid,
+                password = loginState.password,
+                onSuccess = { sessionId ->
                     loginViewModel.getUser(sessionId)
-                    attemptSignIn = false
-                }, onWrongCredentials = {
+                    loginViewModel.onLoginPressed()
+                },
+                onWrongCredentials = {
                     onWrongCredentials()
-                    if (!tryCacheLogin) {
-                        // Toast is only shown for non-cache login attempts
-                        showWrongCredentialsToast(context)
-                    } else {
-                        // If the login attempt was from credentials stored locally, they
-                        // were incorrect and the user needs to login again.
-                        netId = ""
-                        password = ""
-                    }
-                    tryCacheLogin = false
-                    attemptSignIn = false
+//                    if (!tryCacheLogin) {
+//                        // Toast is only shown for non-cache login attempts
+//                        showWrongCredentialsToast(context)
+//                    } else {
+//                        // If the login attempt was from credentials stored locally, they
+//                        // were incorrect and the user needs to login again.
+//                        netId = ""
+//                        password = ""
+//                    }
+//                    tryCacheLogin = false
+//                    attemptSignIn = false
                 })
-            }
-        }
 
-        when (loginViewModel.loginState) {
-            LoginState.Pending -> {
-
-            }
-
-            LoginState.Error -> {
-                onError()
-            }
-
-            is LoginState.Success -> {
-                loginViewModel.saveLoginInfo(netId, password)
-                onSuccess((loginViewModel.loginState as LoginState.Success).user)
-            }
         }
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/components/login/LoginPage.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/components/login/LoginPage.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.android.eateryblue.ui.components.login
 
+import android.util.Log
 import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.WebView
@@ -184,7 +185,6 @@ fun LoginPage(
 
             LoginState.Error -> {
                 onError()
-                TODO("user endpoint doesn't exist on backend so logging in is failing everytime")
             }
 
             is LoginState.Success -> {
@@ -207,14 +207,18 @@ fun LoginWebView(
 
     AndroidView(factory = {
         WebView(it).apply {
-            layoutParams = ViewGroup.LayoutParams(0, 0)
-            settings.javaScriptEnabled = true
-            webViewClient = CustomWebViewClient(
-                netId = netId,
-                password = password,
-                onSuccess = onSuccess,
-                onWrongCredentials = onWrongCredentials,
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
             )
+            settings.javaScriptEnabled = true
+            webViewClient =
+                CustomWebViewClient(
+                    netId = netId,
+                    password = password,
+                    onSuccess = onSuccess,
+                    onWrongCredentials = onWrongCredentials,
+                )
             loadUrl(BuildConfig.SESSIONID_WEBVIEW_URL)
         }
     }, update = {
@@ -236,6 +240,7 @@ class CustomWebViewClient(
         lastUrl = url
         if (url?.contains("sessionId=") == true) {
             val sessionToken = url.substringAfter("sessionId=").removeSuffix("&")
+            Log.d("SESSIONIDDDDD", sessionToken)
             onSuccess(sessionToken)
         } else if (attempts > 1) {
             onWrongCredentials()

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/navigation/MainTabbedNavigation.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/navigation/MainTabbedNavigation.kt
@@ -276,15 +276,15 @@ fun SetupNavHost(
                     Routes.LEGAL to { navController.navigate(Routes.LEGAL.route) },
                     Routes.PRIVACY to { navController.navigate(Routes.PRIVACY.route) },
                     Routes.SUPPORT to { navController.navigate(Routes.SUPPORT.route) },
-//                    Routes.PROFILE to {
-//                        navController.navigate("${Routes.PROFILE.route}/false") {
-//                            if (navController.isOnBackStack(Routes.ACCOUNT.route)) {
-//                                popUpTo(Routes.ACCOUNT.route) { inclusive = true }
-//                            } else {
-//                                popUpTo(Routes.SETTINGS.route) { inclusive = true }
-//                            }
-//                        }
-//                    }
+                    Routes.PROFILE to {
+                        navController.navigate("${Routes.PROFILE.route}/false") {
+                            if (navController.isOnBackStack(Routes.ACCOUNT.route)) {
+                                popUpTo(Routes.ACCOUNT.route) { inclusive = true }
+                            } else {
+                                popUpTo(Routes.SETTINGS.route) { inclusive = true }
+                            }
+                        }
+                    }
                 )
             )
 

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/navigation/NavigationItem.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/navigation/NavigationItem.kt
@@ -56,7 +56,7 @@ sealed class NavigationItem(
         val bottomNavTabList = listOf(
             Home,
             Upcoming,
-            //Profile
+            Profile
 
         )
     }

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/ProfileScreen.kt
@@ -27,6 +27,7 @@ import com.cornellappdev.android.eateryblue.ui.theme.EateryBlue
 import com.cornellappdev.android.eateryblue.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eateryblue.ui.theme.GraySix
 
+
 @Composable
 fun ProfileScreen(
     autoLogin: Boolean = true,
@@ -34,35 +35,6 @@ fun ProfileScreen(
     onLoginSuccess: (user: User) -> Unit
 ) {
     var attemptAutoLogin by remember { mutableStateOf(autoLogin) }
-//    Log.d("profileScreen", attemptAutoLogin.toString())
-//
-//    AnimatedVisibility(visible = attemptAutoLogin) {
-//        Box(
-//            modifier = Modifier
-//                .fillMaxSize()
-//        ) {
-//            Column(modifier = Modifier.align(Alignment.Center)) {
-//                Text(
-//                    text = "Attempting to login...",
-//                    modifier = Modifier
-//                        .align(Alignment.CenterHorizontally)
-//                        .padding(bottom = 10.dp),
-//                    style = TextStyle(fontWeight = FontWeight.Medium, fontSize = 18.sp),
-//                    color = EateryBlue
-//                )
-//
-//                LinearProgressIndicator(
-//                    modifier = Modifier
-//                        .fillMaxWidth()
-//                        .height(15.dp)
-//                        .padding(horizontal = 30.dp),
-//                    backgroundColor = Color.White,
-//                    color = EateryBlue
-//                )
-//            }
-//        }
-//    }
-//
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/ProfileScreen.kt
@@ -10,31 +10,22 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.cornellappdev.android.eateryblue.data.models.User
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.android.eateryblue.ui.components.login.LoginPage
-import com.cornellappdev.android.eateryblue.ui.theme.EateryBlue
-import com.cornellappdev.android.eateryblue.ui.theme.EateryBlueTypography
-import com.cornellappdev.android.eateryblue.ui.theme.GraySix
+import com.cornellappdev.android.eateryblue.ui.viewmodels.LoginViewModel
 
 
 @Composable
 fun ProfileScreen(
-    autoLogin: Boolean = true,
+    loginViewModel: LoginViewModel = hiltViewModel(),
     onSettingsClicked: () -> Unit,
-    onLoginSuccess: (user: User) -> Unit
 ) {
-    var attemptAutoLogin by remember { mutableStateOf(autoLogin) }
+    val state = loginViewModel.state.collectAsState().value
 
     Column(
         modifier = Modifier
@@ -53,26 +44,18 @@ fun ProfileScreen(
                 tint = Color.Black
             )
         }
+        when (state) {
+            is LoginViewModel.State.Login -> {
+                LoginPage(
+                    loginState = state,
+                    loginViewModel = loginViewModel
+                )
+            }
 
-        Text(
-            text = "Log in with Eatery",
-            style = EateryBlueTypography.h3,
-            color = EateryBlue
-        )
-
-        Text(
-            text = "See your meal swipes, BRBs, and more",
-            style = TextStyle(fontWeight = FontWeight.Medium, fontSize = 18.sp),
-            color = GraySix,
-            modifier = Modifier.padding(top = 7.dp)
-        )
-
-        LoginPage(onSuccess = onLoginSuccess, onError = {
-            attemptAutoLogin = false
-        }, onAutoLoginFail = {
-            attemptAutoLogin = false
-        }) {
-            attemptAutoLogin = false
+            is LoginViewModel.State.Account -> {
+                Text(text = state.user.phone!!)
+            }
         }
+
     }
 }


### PR DESCRIPTION
**Overview**
I restored the Login screen and edited networking requests to also use GET endpoint.

**Changes**
- In NetworkAPI.kt, changed POST requests for user, accounts, and transaction history to use GET url
- Uncommented the Profile item in NavigationItem.kt and restored navigation to Profile screen in MainTabbedNavigation.kt
- Changed the types of TransactionType and Date in User.kt to be String and Int (was getting type errors in networking calls)
- Deleted animation from ProfileScreen.kt

Essentially, we are using an invisible WebView to log the user in, using the netId and password they input into our text fields. Then, we connect with the GET backend url to retrieve account information and store it in LoginViewModel. Finally, on a successful login attempt, the profile screen should go blank since we haven't added any display elements yet.

**Testing** 
I manually tested it. Note: did not account for if user does not Duo Authenticate in time (perhaps adding an internal timer to reenable the login button and restart the process).

**Screenshots/Videos**

[connectingtoGETurl.webm](https://github.com/cuappdev/eatery-blue-android/assets/69655767/0453d133-b5c0-4d52-a2c5-ae182c8eab0f)

This demonstrates what a successful login attempt should look like. In the long pause after I click Log In, I am Duo Authenticating, but it also takes a little time to load the data from GET.