### PR TITLE
Fix Lazy Row Bug with Sudden Cutoff

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/HomeScreen.kt
@@ -360,7 +360,6 @@ fun HomeScreen(
                                 item {
                                     Column(
                                         modifier = Modifier.padding(
-                                            start = 16.dp,
                                             bottom = 24.dp,
                                             top = 12.dp
                                         )
@@ -368,7 +367,7 @@ fun HomeScreen(
                                         Row(
                                             modifier = Modifier
                                                 .fillMaxWidth()
-                                                .padding(bottom = 17.dp, end = 16.dp),
+                                                .padding(start = 16.dp, bottom = 17.dp, end = 16.dp),
                                             horizontalArrangement = Arrangement.SpaceBetween,
                                         ) {
                                             Text(
@@ -396,6 +395,9 @@ fun HomeScreen(
                                         }
 
                                         LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                                            item {
+                                                Spacer(modifier = Modifier.width(4.dp))
+                                            }
                                             items(favorites) { eatery ->
                                                 EateryCard(
                                                     eatery = eatery,
@@ -420,14 +422,13 @@ fun HomeScreen(
                                 item {
                                     Column(
                                         modifier = Modifier.padding(
-                                            start = 16.dp,
                                             bottom = 24.dp
                                         )
                                     ) {
                                         Row(
                                             modifier = Modifier
                                                 .fillMaxWidth()
-                                                .padding(bottom = 17.dp, end = 16.dp),
+                                                .padding(start = 16.dp, bottom = 17.dp, end = 16.dp),
                                             horizontalArrangement = Arrangement.SpaceBetween,
                                         ) {
                                             Text(
@@ -436,6 +437,9 @@ fun HomeScreen(
                                             )
                                         }
                                         LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                                            item {
+                                                Spacer(modifier = Modifier.width(4.dp))
+                                            }
                                             items(nearestEateries) { eatery ->
                                                 EateryCard(
                                                     eatery = eatery,
@@ -469,14 +473,13 @@ fun HomeScreen(
 
                                     Column(
                                         modifier = Modifier.padding(
-                                            start = 16.dp,
                                             bottom = 24.dp
                                         )
                                     ) {
                                         Row(
                                             modifier = Modifier
                                                 .fillMaxWidth()
-                                                .padding(bottom = 17.dp, end = 16.dp),
+                                                .padding(start = 16.dp, bottom = 17.dp, end = 16.dp),
                                             horizontalArrangement = Arrangement.SpaceBetween,
                                         ) {
                                             Text(
@@ -486,6 +489,9 @@ fun HomeScreen(
 
                                         }
                                         LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                                            item {
+                                                Spacer(modifier = Modifier.width(4.dp))
+                                            }
                                             items(swipeEateries) { eatery ->
                                                 EateryCard(
                                                     eatery = eatery,


### PR DESCRIPTION
## Overview
Resolved a bug that made the LazyRows on the home screen cutoff due to padding.

## Changes Made
Added `Spacers`
- Located in `HomeScreen.kt`
- Spacer of width `4.dp` due to the spacing between items being `12.dp`

## Test Coverage
Manually tested on my trusty Samsung S21

## Screenshots & Videos
### Current
![Screenshot_20231108_135340_Eatery_Blue](https://github.com/cuappdev/eatery-blue-android/assets/36115868/6ef69c94-d4e0-44cb-8bc5-ae2a6bf7ca0f)
### Updated
![Screenshot_20231108_135302_Eatery_Blue](https://github.com/cuappdev/eatery-blue-android/assets/36115868/3fe7957c-b969-4985-94a9-92bda7cbbcfe)


