### PR TITLE
Fixed - Mealplan Crash, Select Menu Color, Current Meal

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eateryblue/data/models/Eatery.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/data/models/Eatery.kt
@@ -103,6 +103,13 @@ data class Eatery(
         return todayEvents
     }
 
+    fun getCurrentEvent(): Event? {
+        return getTodaysEvents().find {
+            it.startTime?.isBefore(LocalDateTime.now()) ?: true
+                    && it.endTime?.isAfter(LocalDateTime.now()) ?: true
+        }
+    }
+
     fun getSelectedDayMeal(meal: Int, day: Int): List<Event>? {
         var currentDay = LocalDate.now()
         currentDay = currentDay.plusDays(day.toLong())

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/components/login/AccountPage.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/components/login/AccountPage.kt
@@ -414,10 +414,7 @@ fun AccountBalanceRow(
 ) {
     fun findMealPlan(): String {
         return "%.0f".format(
-            loginViewModel.checkAccount(AccountType.UNLIMITED)?.balance
-                ?: loginViewModel.checkAccount(AccountType.BEAR_BASIC)?.balance
-                ?: loginViewModel.checkAccount(AccountType.BEAR_CHOICE)?.balance
-                ?: loginViewModel.checkAccount(AccountType.BEAR_TRADITIONAL)?.balance ?: 0
+            loginViewModel.checkAccounts()?.balance ?: 0
         )
     }
     Row(
@@ -433,9 +430,9 @@ fun AccountBalanceRow(
             modifier = Modifier.weight(1f),
             textAlign = TextAlign.Right,
             text = if (accountType != AccountType.MEALSWIPES) {
-                "$" + "%.2f".format(loginViewModel.checkAccount(accountType)?.balance ?: 0)
+                "$" + "%.2f".format(loginViewModel.checkAccounts()?.balance ?: 0)
             } else {
-                (findMealPlan()).toString() + " remaining this week"
+                findMealPlan() + " remaining this week"
             },
             style = EateryBlueTypography.button,
         )

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/screens/EateryDetailScreen.kt
@@ -72,7 +72,7 @@ fun EateryDetailScreen(
     var sheetContent by remember { mutableStateOf(BottomSheetContent.PAYMENT_METHODS_AVAILABLE) }
     val paymentMethods = remember { mutableStateListOf<PaymentMethodsAvailable>() }
     val coroutineScope = rememberCoroutineScope()
-    var issue by remember { mutableStateOf<Issue?>(null) }
+    val issue by remember { mutableStateOf<Issue?>(null) }
 
     when (val eateryApiResponse = eateryDetailViewModel.eatery.value) {
         is EateryApiResponse.Pending -> {
@@ -409,9 +409,11 @@ fun EateryDetailScreen(
                                 .background(GrayZero)
                         )
 
-                        eatery.getTodaysEvents().forEach { event ->
-                            EateryMenuWidget(event = event)
+                        val nextEvent: Event? = eatery.getCurrentEvent()
+                        if (nextEvent != null) {
+                            EateryMenuWidget(event = nextEvent)
                         }
+
 
                         Spacer(
                             modifier = Modifier
@@ -563,16 +565,16 @@ fun AlertsSection(eatery: Eatery) {
 @Composable
 fun EateryMenuWidget(event: Event) {
     /** Handles the number and calender at the top*/
-    var zoneId: ZoneId? = ZoneId.of("America/New_York")
-    var today = LocalDate.now(zoneId)
-    var currentDay by remember { mutableStateOf(today) }
+    val zoneId: ZoneId? = ZoneId.of("America/New_York")
+    val today = LocalDate.now(zoneId)
+    val currentDay by remember { mutableStateOf(today) }
     Log.d("current day", currentDay.dayOfWeek.value.toString())
     Log.d("current day2", currentDay.dayOfMonth.toString())
-    var dayWeek: Int = currentDay.dayOfWeek.value
+    val dayWeek: Int = currentDay.dayOfWeek.value
     val dayNum: Int = currentDay.dayOfMonth
-    var dayNames = mutableListOf<String>()
-    var dayWeeks = mutableListOf<Int>()
-    var days = mutableListOf<Int>()
+    val dayNames = mutableListOf<String>()
+    val dayWeeks = mutableListOf<Int>()
+    val days = mutableListOf<Int>()
 
 
     dayWeeks.add(dayWeek)
@@ -597,9 +599,9 @@ fun EateryMenuWidget(event: Event) {
         dayNames.add(dayName)
     }
 
-    val coroutineScope = rememberCoroutineScope()
+    rememberCoroutineScope()
 
-    var weekDayIndex = 0
+    val weekDayIndex = 0
     var selectedDay by remember { mutableStateOf(weekDayIndex) }
     var openUpcoming by remember { mutableStateOf(false) }
     var filterText by remember { mutableStateOf("") }

--- a/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/LoginViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eateryblue/ui/viewmodels/LoginViewModel.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.android.eateryblue.ui.viewmodels
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.android.eateryblue.data.models.Account
@@ -52,12 +53,33 @@ class LoginViewModel @Inject constructor(
     // Convert the state to a flow that can be updated by screens that use the LoginViewModel
     val state = _state.asStateFlow()
 
-    //
-    fun checkAccount(accountType: AccountType): Account? {
-        if (_state.value !is State.Account || CurrentUser.user == null) return null
-        return CurrentUser.user!!.accounts!!.find { account -> account.type == accountType }
-    }
+    // List of all available meal plans
+    val mealPlanList = mutableListOf(
+        AccountType.FLEX,
+        AccountType.BEAR_TRADITIONAL,
+        AccountType.BEAR_CHOICE,
+        AccountType.BEAR_BASIC,
+        AccountType.UNLIMITED,
+        AccountType.HOUSE_AFFILIATE,
+        AccountType.HOUSE_MEALPLAN,
+        AccountType.JUST_BUCKS,
+        AccountType.OFF_CAMPUS
+    )
 
+    // Check what the meal plan is against our list of meal plans
+    fun checkAccounts(): Account? {
+        if (_state.value !is State.Account || CurrentUser.user == null) return null
+        var currAccount: Account? = null
+        CurrentUser.user!!.accounts!!.forEach {
+            if (mealPlanList.contains(it.type)) {
+                Log.d("Mealplan", it.type.toString())
+                currAccount = it
+            }
+        }
+        Log.d("Final Plan", currAccount!!.type.toString())
+        return currAccount
+    }
+    
     fun updateAccountFilter(newAccountType: AccountType) {
         val currState = _state.value
         if (currState !is State.Account) return


### PR DESCRIPTION
## Overview
Fixed crashes due to lack of meal plan support and made it so only the current meal occurring at the time is displayed by on the eatery details screen. Also fixed the coloring of the individual upcoming menu.

## Changes Made
Created function `getCurrentEvent`
- Located in `Eatery.kt`
- Returns all the current meal for the day.

Created function `checkAccounts`
- Located in `LoginViewModel.kt`
- Returns the number of swipes for the meal plan the user has by checking the accounts meal plan against a list of all meal plans.

## Test Coverage
Manually tested on my trusty Samsung S21

## Issues Resolved
#77 #67