### PR TITLE
Helen/sticky header

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,15 +16,15 @@ def secretsProperties = new Properties()
 secretsProperties.load(new FileInputStream(secretsPropertiesFile))
 
 android {
-    namespace 'com.cornellappdev.android.eateryblue'
+    namespace 'com.cornellappdev.android.eatery'
     compileSdk 34
 
     defaultConfig {
-        applicationId "com.cornellappdev.android.eateryblue"
+        applicationId "com.cornellappdev.android.eatery"
         minSdk 28
         targetSdk 34
-        versionCode 67
-        versionName "release-2.0-compatability"
+        versionCode 69
+        versionName "blue-1.0.1-crashfix"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -77,7 +77,7 @@ kapt {
 }
 
 dependencies {
-    implementation 'androidx.compose.ui:ui-unit-android:1.6.6'
+    testImplementation 'junit:junit:4.12'
     def nav_version = "2.5.3"
     def compose_version = "1.3.1"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,15 +16,15 @@ def secretsProperties = new Properties()
 secretsProperties.load(new FileInputStream(secretsPropertiesFile))
 
 android {
-    namespace 'com.cornellappdev.android.eatery'
+    namespace 'com.cornellappdev.android.eateryblue'
     compileSdk 34
 
     defaultConfig {
-        applicationId "com.cornellappdev.android.eatery"
+        applicationId "com.cornellappdev.android.eateryblue"
         minSdk 28
         targetSdk 34
-        versionCode 69
-        versionName "blue-1.0.1-crashfix"
+        versionCode 67
+        versionName "release-2.0-compatability"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -77,7 +77,7 @@ kapt {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
+    implementation 'androidx.compose.ui:ui-unit-android:1.6.6'
     def nav_version = "2.5.3"
     def compose_version = "1.3.1"
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryDetailsStickyHeader.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryDetailsStickyHeader.kt
@@ -36,7 +36,7 @@ fun EateryDetailsStickyHeader(
     nextEvent: Event?,
     eatery: Eatery,
     filterText: String,
-    onItemClick: (Int) -> Unit // Callback function to handle item click
+    onItemClick: (Int) -> Unit
 ) {
     val targetPosition = remember { mutableStateOf(IntOffset.Zero) }
 
@@ -68,7 +68,7 @@ fun EateryDetailsStickyHeader(
                 }
             } ?: emptyList()
 
-            if (filteredItemsList.isNotEmpty()) {
+            if (!filteredItemsList.isNullOrEmpty()) {
                 LazyRow(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -83,7 +83,6 @@ fun EateryDetailsStickyHeader(
                     }
 
                     nextEvent?.menu?.forEachIndexed { index, category: MenuCategory ->
-                        if (!filteredItemsList.isNullOrEmpty()) {
                             item {
                                 MenuItem(
                                     category = category,
@@ -97,7 +96,6 @@ fun EateryDetailsStickyHeader(
                                         .width(10.dp)
                                 )
                             }
-                        }
                     }
 
                     item {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryDetailsStickyHeader.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryDetailsStickyHeader.kt
@@ -1,66 +1,106 @@
 package com.cornellappdev.android.eatery.ui.components.details
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.android.eatery.data.models.Eatery
 import com.cornellappdev.android.eatery.data.models.Event
 import com.cornellappdev.android.eatery.data.models.MenuCategory
 import com.cornellappdev.android.eatery.ui.theme.GrayFive
 import com.cornellappdev.android.eatery.ui.theme.GrayZero
+import com.cornellappdev.android.eatery.ui.theme.Yellow
+import com.cornellappdev.android.eatery.ui.viewmodels.EateryDetailViewModel
 
 @Composable
 fun EateryDetailsStickyHeader(
     nextEvent: Event?,
     eatery: Eatery,
     filterText: String,
+    fullMenuList: MutableList<String>,
+    listState: LazyListState,
+    eateryDetailViewModel: EateryDetailViewModel = hiltViewModel(),
     onItemClick: (Int) -> Unit
 ) {
-    val targetPosition = remember { mutableStateOf(IntOffset.Zero) }
-
     Column {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(Color.White)
-                .padding(top = 56.dp, bottom = 12.dp)
+                .padding(top = 48.dp, bottom = 12.dp)
         ) {
-            Text(
-                modifier = Modifier
-                    .height(24.dp)
-                    .fillMaxWidth(),
-                textAlign = TextAlign.Center,
-                text = eatery.name ?: "Loading...",
-                color = GrayFive,
-                style = TextStyle(
-                    fontWeight = FontWeight.SemiBold,
-                    fontSize = 20.sp
+            Box(modifier = Modifier.fillMaxWidth().height(40.dp)) {
+                Text(
+                    modifier = Modifier
+                        .height(24.dp)
+                        .widthIn(0.dp, 280.dp)
+                        .align(Alignment.Center),
+                    textAlign = TextAlign.Center,
+                    text = eatery.name ?: "Loading...",
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = GrayFive,
+                    style = TextStyle(
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 20.sp
+                    )
                 )
-            )
 
-            Spacer(modifier = Modifier.height(16.dp))
+                Button(
+                    onClick = { eateryDetailViewModel.toggleFavorite() },
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .padding(end = 16.dp)
+                        .size(40.dp),
+                    contentPadding = PaddingValues(6.dp),
+                    shape = CircleShape,
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = Color.White,
+                    ),
+                    elevation = ButtonDefaults.elevation(defaultElevation = 0.dp, pressedElevation = 0.dp)
+                ) {
+                    Icon(
+                        imageVector = if (eateryDetailViewModel.isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                        tint = if (eateryDetailViewModel.isFavorite) Yellow else GrayFive,
+                        contentDescription = null
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
 
             val filteredItemsList = nextEvent?.menu?.mapNotNull { category ->
                 category.items?.filter {
@@ -69,6 +109,7 @@ fun EateryDetailsStickyHeader(
             } ?: emptyList()
 
             if (!filteredItemsList.isNullOrEmpty()) {
+
                 LazyRow(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -82,20 +123,23 @@ fun EateryDetailsStickyHeader(
                         )
                     }
 
-                    nextEvent?.menu?.forEachIndexed { index, category: MenuCategory ->
-                            item {
-                                MenuItem(
-                                    category = category,
-                                    onItemClick = { onItemClick(index) }
-                                )
-                            }
-                            item {
-                                Spacer(
-                                    modifier = Modifier
-                                        .fillMaxHeight()
-                                        .width(10.dp)
-                                )
-                            }
+                    nextEvent?.menu?.forEach { category ->
+                        item {
+                            val categoryIndex = fullMenuList.indexOf(category.category)
+                            CategoryItem(
+                                category,
+                                listState,
+                                nextEvent,
+                                fullMenuList
+                            ) { onItemClick(categoryIndex) }
+                        }
+                        item {
+                            Spacer(
+                                modifier = Modifier
+                                    .fillMaxHeight()
+                                    .width(10.dp)
+                            )
+                        }
                     }
 
                     item {
@@ -118,14 +162,25 @@ fun EateryDetailsStickyHeader(
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun MenuItem(
+fun CategoryItem(
     category: MenuCategory,
+    listState: LazyListState,
+    nextEvent: Event?,
+    fullMenuList: MutableList<String>,
     onItemClick: () -> Unit
 ) {
+    val isHighlighted = highlightCategory(
+        category,
+        listState,
+        nextEvent,
+        fullMenuList
+    )
+    val backgroundColor = if (isHighlighted) Color.Black else Color.White
+    val textColor = if (isHighlighted) Color.White else GrayFive
     Surface(
         modifier = Modifier.fillMaxHeight(),
         shape = RoundedCornerShape(100),
-        color = Color.White,
+        color = backgroundColor,
         onClick = onItemClick
     ) {
         Text(
@@ -133,11 +188,35 @@ fun MenuItem(
                 .height(180.dp)
                 .padding(vertical = 8.dp, horizontal = 10.dp),
             text = category.category ?: "Category",
-            color = GrayFive,
+            color = textColor,
             style = TextStyle(
                 fontWeight = FontWeight.SemiBold,
                 fontSize = 14.sp
             )
         )
     }
+}
+
+@Composable
+fun highlightCategory(category: MenuCategory, listState: LazyListState, nextEvent: Event?, fullMenuList: MutableList<String>): Boolean {
+        val firstMenuItemIndex = listState.firstVisibleItemIndex - 5
+
+        if (firstMenuItemIndex >= 0 && firstMenuItemIndex < fullMenuList.size) {
+            val item = fullMenuList[firstMenuItemIndex]
+            val isCategoryName = nextEvent?.menu?.any { category ->
+                category.category == item
+            } ?: false
+
+            if(isCategoryName) {
+                return category.category == item
+            } else {
+                for (i in firstMenuItemIndex - 1 downTo 0) {
+                    val previousItem = fullMenuList[i]
+                    if (nextEvent?.menu?.any { category -> category.category == previousItem } == true) {
+                        return category.category == previousItem
+                    }
+                }
+            }
+        }
+    return false
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryDetailsStickyHeader.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryDetailsStickyHeader.kt
@@ -99,14 +99,14 @@ fun EateryDetailsStickyHeader(
             ) {
                 Text(
                     modifier = Modifier
-                        .height(24.dp)
+                        .height(26.dp)
                         .widthIn(0.dp, 280.dp)
                         .align(Alignment.Center),
                     textAlign = TextAlign.Center,
                     text = eatery.name ?: "Loading...",
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    color = GrayFive,
+                    color = Color.Black,
                     style = TextStyle(
                         fontWeight = FontWeight.SemiBold,
                         fontSize = 20.sp
@@ -137,7 +137,7 @@ fun EateryDetailsStickyHeader(
                 }
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(6.dp))
 
             val filteredItemsList = nextEvent?.menu?.mapNotNull { category ->
                 category.items?.filter {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryDetailsStickyHeader.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryDetailsStickyHeader.kt
@@ -1,0 +1,145 @@
+package com.cornellappdev.android.eatery.ui.components.details
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.cornellappdev.android.eatery.data.models.Eatery
+import com.cornellappdev.android.eatery.data.models.Event
+import com.cornellappdev.android.eatery.data.models.MenuCategory
+import com.cornellappdev.android.eatery.ui.theme.GrayFive
+import com.cornellappdev.android.eatery.ui.theme.GrayZero
+
+@Composable
+fun EateryDetailsStickyHeader(
+    nextEvent: Event?,
+    eatery: Eatery,
+    filterText: String,
+    onItemClick: (Int) -> Unit // Callback function to handle item click
+) {
+    val targetPosition = remember { mutableStateOf(IntOffset.Zero) }
+
+    Column {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White)
+                .padding(top = 56.dp, bottom = 12.dp)
+        ) {
+            Text(
+                modifier = Modifier
+                    .height(24.dp)
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                text = eatery.name ?: "Loading...",
+                color = GrayFive,
+                style = TextStyle(
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 20.sp
+                )
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            val filteredItemsList = nextEvent?.menu?.mapNotNull { category ->
+                category.items?.filter {
+                    it.name?.contains(filterText, true) ?: false
+                }
+            } ?: emptyList()
+
+            if (filteredItemsList.isNotEmpty()) {
+                LazyRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(34.dp)
+                ) {
+                    item {
+                        Spacer(
+                            modifier = Modifier
+                                .fillMaxHeight()
+                                .width(16.dp)
+                        )
+                    }
+
+                    nextEvent?.menu?.forEachIndexed { index, category: MenuCategory ->
+                        if (!filteredItemsList.isNullOrEmpty()) {
+                            item {
+                                MenuItem(
+                                    category = category,
+                                    onItemClick = { onItemClick(index) }
+                                )
+                            }
+                            item {
+                                Spacer(
+                                    modifier = Modifier
+                                        .fillMaxHeight()
+                                        .width(10.dp)
+                                )
+                            }
+                        }
+                    }
+
+                    item {
+                        Spacer(
+                            modifier = Modifier
+                                .fillMaxHeight()
+                                .width(6.dp)
+                        )
+                    }
+                }
+            }
+        }
+
+        Divider(
+            color = GrayZero,
+            thickness = 1.dp
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun MenuItem(
+    category: MenuCategory,
+    onItemClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxHeight(),
+        shape = RoundedCornerShape(100),
+        color = Color.White,
+        onClick = onItemClick
+    ) {
+        Text(
+            modifier = Modifier
+                .height(180.dp)
+                .padding(vertical = 8.dp, horizontal = 10.dp),
+            text = category.category ?: "Category",
+            color = GrayFive,
+            style = TextStyle(
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 14.sp
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryDetailsStickyHeader.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryDetailsStickyHeader.kt
@@ -248,6 +248,8 @@ fun highlightCategory(
     fullMenuList: MutableList<String>
 ): Boolean {
     val firstVisibleState = remember { derivedStateOf { listState.firstVisibleItemIndex } }
+    // Note: - 5 here assumes that there are 5 UI elements above the menu, which is true currently.
+    //  If that changes, this must be tweaked.
     val firstMenuItemIndex = firstVisibleState.value - 5
 
     if (firstMenuItemIndex >= 0 && firstMenuItemIndex < fullMenuList.size) {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -762,7 +762,8 @@ fun EateryDetailScreen(
                         enter = fadeIn(animationSpec = tween(100)),
                         exit = fadeOut(animationSpec = tween(100))) {
                         EateryDetailsStickyHeader(nextEvent, eatery, filterText) { index ->
-                            coroutineScope.launch { listState.animateScrollToItem(index + 8) }
+                            println("Clicked item index: $index")
+                            coroutineScope.launch { listState.animateScrollToItem(index + 7) }
                         }
                     }
                 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -33,7 +32,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
@@ -52,9 +50,7 @@ import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -104,11 +100,10 @@ import com.cornellappdev.android.eatery.ui.viewmodels.EateryDetailViewModel
 import com.cornellappdev.android.eatery.ui.viewmodels.state.EateryApiResponse
 import com.valentinilk.shimmer.ShimmerBounds
 import com.valentinilk.shimmer.rememberShimmer
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import java.time.format.DateTimeFormatter
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun EateryDetailScreen(
     eateryDetailViewModel: EateryDetailViewModel = hiltViewModel()
@@ -235,9 +230,16 @@ fun EateryDetailScreen(
                 }
 
                 val listState = rememberLazyListState()
-                val visibleItemIndex = remember(listState) { listState.firstVisibleItemIndex }
 
                 Box {
+                    val fullMenuList = mutableListOf<String>()
+                    nextEvent?.menu?.forEach { category ->
+                        category.category?.let { fullMenuList.add(it) }
+                        category.items?.forEach { item ->
+                            item.name?.let { fullMenuList.add(it) }
+                        }
+                    }
+
                     LazyColumn(
                         state = listState,
                         modifier = Modifier.fillMaxSize()
@@ -761,9 +763,10 @@ fun EateryDetailScreen(
                     AnimatedVisibility(visible = listState.firstVisibleItemIndex >= 1,
                         enter = fadeIn(animationSpec = tween(100)),
                         exit = fadeOut(animationSpec = tween(100))) {
-                        EateryDetailsStickyHeader(nextEvent, eatery, filterText) { index ->
-                            println("Clicked item index: $index")
-                            coroutineScope.launch { listState.animateScrollToItem(index + 7) }
+                        EateryDetailsStickyHeader(nextEvent, eatery, filterText, fullMenuList, listState, eateryDetailViewModel) { index ->
+                            // The first category title has an item index of 8
+                            // ideal is listState.animateScrollToItem(index + 8, scrollOffset = -400)
+                            coroutineScope.launch { listState.animateScrollToItem(index + 5) }
                         }
                     }
                 }


### PR DESCRIPTION
- Resolves #98 
- Implemented header for EateryDetailsScreen for iOS parity
- I realize that when you scroll to menu categories where the corresponding label in the header is off-screen (and needs to be scrolled to in order to be viewed), the header doesn't perform the scroll automatically like the iOS version -- let me know if you want me to implement that

## Demo
[headerdemo.webm](https://github.com/cuappdev/eatery-blue-android/assets/151488690/f8b88b07-da60-4d30-b66c-7cebe0e4ca7e)
