### PR TITLE
Zach/easy breakfast lunch dinner switch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,66 @@
+## Overview
+
+TODO
+
+## Changes Made
+
+### Change 1
+
+- TODO
+- TODO
+
+### Change 2
+
+- TODO
+- TODO
+
+## Test Coverage
+
+- TODO
+
+## Next Steps (optional)
+
+TODO
+
+## Related PRs or Issues (optional)
+
+TODO
+
+## Screenshots (optional)
+
+<!-- use the following for videos -->
+<details>
+  <summary>TODO</summary>
+  <table>
+    <tr>
+      <td>Before</td>
+      <td>After</td>
+    </tr>
+  <tr>
+    <td><video src="enterurlhere" type="video/mp4"></td>
+    <td><video src="enterurlhere" type="video/mp4"></td>
+  </tr>
+ </table>
+</details>
+
+<!-- use the following for images -->
+<details>
+  <summary>TODO</summary>
+  <table>
+    <tr>
+      <td>Before</td>
+      <td>After</td>
+    </tr>
+  <tr>
+    <td><img src="enterurlhere" width="300px" height="auto"></td>
+    <td><img src="enterurlhere" width="300px" height="auto"></td>
+  </tr>
+ </table>
+</details>
+
+<!-- use the following if there is no before/after -->
+<details>
+  <summary>TODO</summary>
+  <img src="enterurlhere" width="300px" height="auto">
+  <video src="enterurlhere" type="video/mp4">
+</details>

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/models/Eatery.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/models/Eatery.kt
@@ -461,6 +461,9 @@ data class WaitTimeData(
 @JsonClass(generateAdapter = true)
 data class Event(
     @Json(name = "id") val id: Int? = null,
+    /**
+     * Descriptions tend to be "Lunch", "Dinner", etc..
+     */
     @Json(name = "event_description") val description: String? = null,
     @Json(name = "start") val startTime: LocalDateTime? = null,
     @Json(name = "end") val endTime: LocalDateTime? = null,

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/models/Eatery.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/models/Eatery.kt
@@ -159,7 +159,7 @@ data class Eatery(
     }
 
     /**
-     * @returns the association list of mealDescription of one eatery on one day based
+     * @return the association list of mealDescription of one eatery on one day based
      * on chronological order and the duration of that particular meal
      * e.g. for Oken on Mondays, it would return
      * [("Lunch", some string duration),("Dinner", some string duration)]

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/CalendarButton.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/CalendarButton.kt
@@ -1,0 +1,51 @@
+package com.cornellappdev.android.eatery.ui.components.details
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cornellappdev.android.eatery.R
+import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
+import com.cornellappdev.android.eatery.ui.theme.GrayZero
+import com.cornellappdev.android.eatery.util.EateryPreview
+
+@Composable
+fun CalendarButton(onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(100))
+            .background(GrayZero)
+            .clickable { onClick() }
+            .padding(vertical = 8.dp, horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    )
+    {
+        Icon(
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_calendar),
+            contentDescription = "Change date",
+            modifier = Modifier.size(16.dp)
+        )
+
+        Text("Change date", style = EateryBlueTypography.button)
+    }
+}
+
+@Preview
+@Composable
+fun CalendarButtonPreview() = EateryPreview {
+    CalendarButton { }
+}

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/CalendarButton.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/CalendarButton.kt
@@ -46,6 +46,6 @@ fun CalendarButton(onClick: () -> Unit) {
 
 @Preview
 @Composable
-fun CalendarButtonPreview() = EateryPreview {
+private fun CalendarButtonPreview() = EateryPreview {
     CalendarButton { }
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryMealTabs.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryMealTabs.kt
@@ -17,7 +17,7 @@ import com.cornellappdev.android.eatery.util.EateryPreview
 
 
 @Composable
-fun EateryMealTabs(selectedMealIndex: Int, onSelectMeal: (String) -> Unit, meals: List<String>) {
+fun EateryMealTabs(selectedMealIndex: Int, onSelectMeal: (Int) -> Unit, meals: List<String>) {
     TabRow(selectedTabIndex = selectedMealIndex, indicator = { tabPositions ->
         TabRowDefaults.Indicator(
             Modifier.tabIndicatorOffset(tabPositions[selectedMealIndex]),
@@ -29,7 +29,7 @@ fun EateryMealTabs(selectedMealIndex: Int, onSelectMeal: (String) -> Unit, meals
             Tab(
                 selected = index == selectedMealIndex,
                 onClick = {
-                    onSelectMeal(meal)
+                    onSelectMeal(index)
                 },
             ) {
                 Text(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryMealTabs.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryMealTabs.kt
@@ -1,0 +1,55 @@
+package com.cornellappdev.android.eatery.ui.components.details
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
+import com.cornellappdev.android.eatery.ui.theme.GrayThree
+import com.cornellappdev.android.eatery.util.EateryPreview
+
+
+@Composable
+fun EateryMealTabs(selectedMealIndex: Int, onSelectMeal: (String) -> Unit, meals: List<String>) {
+    TabRow(selectedTabIndex = selectedMealIndex, indicator = { tabPositions ->
+        TabRowDefaults.Indicator(
+            Modifier.tabIndicatorOffset(tabPositions[selectedMealIndex]),
+            color = Color.Black,
+            height = 1.dp,
+        )
+    }) {
+        meals.mapIndexed { index, meal ->
+            Tab(
+                selected = index == selectedMealIndex,
+                onClick = {
+                    onSelectMeal(meal)
+                },
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 12.dp),
+            ) {
+                Text(
+                    meal, style = EateryBlueTypography.button.copy(
+                        color =
+                        if (index == selectedMealIndex) {
+                            Color.Black
+                        } else {
+                            GrayThree
+                        }
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun EateryMealTabsPreview() = EateryPreview {
+    EateryMealTabs(0, {}, listOf("Breakfast", "Lunch", "Dinner"))
+}

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryMealTabs.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryMealTabs.kt
@@ -31,17 +31,18 @@ fun EateryMealTabs(selectedMealIndex: Int, onSelectMeal: (String) -> Unit, meals
                 onClick = {
                     onSelectMeal(meal)
                 },
-                modifier = Modifier.padding(horizontal = 10.dp, vertical = 12.dp),
             ) {
                 Text(
-                    meal, style = EateryBlueTypography.button.copy(
+                    meal,
+                    style = EateryBlueTypography.button.copy(
                         color =
                         if (index == selectedMealIndex) {
                             Color.Black
                         } else {
                             GrayThree
                         }
-                    )
+                    ),
+                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 12.dp),
                 )
             }
         }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryMenusBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryMenusBottomSheet.kt
@@ -163,7 +163,7 @@ fun EateryMenusBottomSheet(
                     .fillMaxWidth()
             ) {
                 if (mealTypes != null && mealTypes.size > 1) {
-                    mealTypes?.forEachIndexed { index, (description, duration) ->
+                    mealTypes.forEachIndexed { index, (description, duration) ->
                         if (description != null && duration != null) {
                             Row(
                                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryMenusBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryMenusBottomSheet.kt
@@ -41,6 +41,7 @@ import com.cornellappdev.android.eatery.ui.components.general.CalendarWeekSelect
 import com.cornellappdev.android.eatery.ui.theme.EateryBlue
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eatery.ui.theme.GrayZero
+import com.cornellappdev.android.eatery.util.toReadableShortName
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.ZoneId
@@ -90,16 +91,7 @@ fun EateryMenusBottomSheet(
 
     val closedDays: List<DayOfWeek> = eatery.getClosedDays()
     val closedDaysStrings: List<String> = closedDays.map { dayOfWeek ->
-        when (dayOfWeek.value) {
-            1 -> "Mon"
-            2 -> "Tue"
-            3 -> "Wed"
-            4 -> "Thu"
-            5 -> "Fri"
-            6 -> "Sat"
-            7 -> "Sun"
-            else -> "error"
-        }
+        dayOfWeek.toReadableShortName()
     }
 
     val selectedDayOfWeek = DayOfWeek.of(dayWeeks[currSelectedDay])

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -2,7 +2,6 @@ package com.cornellappdev.android.eatery.ui.screens
 
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.RepeatMode
@@ -50,7 +49,6 @@ import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -128,16 +126,9 @@ fun EateryDetailScreen(
      * The amount of days offset from the current weekday
      */
     var weekDayIndex by remember { mutableStateOf(0) }
-    LaunchedEffect(weekDayIndex) {
-        Log.d("TAG", "EateryDetailScreen: weekday index: $weekDayIndex")
-    }
 
     // The event/meal to display. May be null.
     val nextEvent by eateryDetailViewModel.mealToShow.collectAsState()
-
-    // TODO we are storing state for the currently displayed meal in the ViewModel and the View,
-    //  we should really be only storing this in the ViewModel and hoist the state out of the View
-    //  This should make implementing menu switching much better
 
     // The filter text typed in.
     val filterText by eateryDetailViewModel.searchQueryFlow.collectAsState()

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -133,6 +133,9 @@ fun EateryDetailScreen(
 
     // The event/meal to display. May be null.
     val nextEvent by eateryDetailViewModel.mealToShow.collectAsState()
+    // TODO we are storing state for the currently displayed meal in the ViewModel and the View,
+    //  we should really be only storing this in the ViewModel and hoist the state out of the View
+    //  This should make implementing menu switching much better
     var mealType by remember { mutableStateOf(0) }
 
 
@@ -165,7 +168,6 @@ fun EateryDetailScreen(
             ModalBottomSheetLayout(
                 sheetState = modalBottomSheetState, sheetContent = {
                     when (sheetContent) {
-
                         BottomSheetContent.PAYMENT_METHODS_AVAILABLE -> {
                             PaymentMethodsAvailable(selectedPaymentMethods = paymentMethods) {
                                 coroutineScope.launch {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -630,15 +630,16 @@ fun EateryDetailScreen(
                                 }
                                 eatery.getTypeMeal(weekDayIndex.fromOffsetToDayOfWeek())
                                     .takeIf { it?.size?.let { s -> s > 1 } == true }
+                                    ?.map { it.first }
                                     ?.let { mealTypes ->
                                         item {
                                             EateryMealTabs(
-                                                meals = mealTypes.map { it.first },
+                                                meals = mealTypes,
                                                 onSelectMeal = { selectedMeal ->
                                                     eateryDetailViewModel.selectEvent(
                                                         eatery,
                                                         weekDayIndex,
-                                                        selectedMeal
+                                                        mealTypes[selectedMeal]
                                                     )
                                                 },
                                                 selectedMealIndex = mealTypeIndex.value

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.TabRow
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Report
@@ -79,6 +78,7 @@ import com.cornellappdev.android.eatery.ui.components.details.AlertsSection
 import com.cornellappdev.android.eatery.ui.components.details.CalendarButton
 import com.cornellappdev.android.eatery.ui.components.details.EateryDetailsStickyHeader
 import com.cornellappdev.android.eatery.ui.components.details.EateryHourBottomSheet
+import com.cornellappdev.android.eatery.ui.components.details.EateryMealTabs
 import com.cornellappdev.android.eatery.ui.components.details.EateryMenusBottomSheet
 import com.cornellappdev.android.eatery.ui.components.details.PaymentWidgets
 import com.cornellappdev.android.eatery.ui.components.general.PaymentMethodsAvailable
@@ -632,7 +632,11 @@ fun EateryDetailScreen(
                                 }
 
                                 item {
-
+                                    EateryMealTabs(
+                                        meals = listOf("Breakfast", "Lunch", "Dinner"),
+                                        onSelectMeal = {},
+                                        selectedMealIndex = 0
+                                    )
                                 }
 
                                 nextEvent!!.menu?.forEachIndexed { categoryIndex, category ->

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.TabRow
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Report
@@ -628,6 +629,10 @@ fun EateryDetailScreen(
                                             .height(1.dp)
                                             .background(GrayZero, CircleShape)
                                     )
+                                }
+
+                                item {
+
                                 }
 
                                 nextEvent!!.menu?.forEachIndexed { categoryIndex, category ->

--- a/app/src/main/java/com/cornellappdev/android/eatery/util/DateUtil.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/util/DateUtil.kt
@@ -19,8 +19,6 @@ fun DayOfWeek.toReadableShortName(): String = when (this) {
 
 /**
  * Given an int offset from the current day of the week, return the day of the week in offset days
+ * Example: If day of the week is Monday, and the offset is 1, it would return Tuesday
  */
 fun Int.fromOffsetToDayOfWeek(): DayOfWeek = LocalDate.now().plusDays(this.toLong()).dayOfWeek
-
-val readableDayOfWeek
-    get() = LocalDate.now().dayOfWeek.name.lowercase().replaceFirstChar { c -> c.uppercase() }

--- a/app/src/main/java/com/cornellappdev/android/eatery/util/DateUtil.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/util/DateUtil.kt
@@ -1,0 +1,26 @@
+package com.cornellappdev.android.eatery.util
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+
+fun DayOfWeek.toReadableFullName(): String =
+    this.name.lowercase().replaceFirstChar { c -> c.uppercase() }
+
+fun DayOfWeek.toReadableShortName(): String = when (this) {
+    DayOfWeek.MONDAY -> "Mon"
+    DayOfWeek.TUESDAY -> "Tue"
+    DayOfWeek.WEDNESDAY -> "Wed"
+    DayOfWeek.THURSDAY -> "Thu"
+    DayOfWeek.FRIDAY -> "Fri"
+    DayOfWeek.SATURDAY -> "Sat"
+    DayOfWeek.SUNDAY -> "Sun"
+}
+
+/**
+ * Given an int offset from the current day of the week, return the day of the week in offset days
+ */
+fun Int.fromOffsetToDayOfWeek(): DayOfWeek = LocalDate.now().plusDays(this.toLong()).dayOfWeek
+
+val readableDayOfWeek
+    get() = LocalDate.now().dayOfWeek.name.lowercase().replaceFirstChar { c -> c.uppercase() }

--- a/app/src/main/java/com/cornellappdev/android/eatery/util/PreviewUtil.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/util/PreviewUtil.kt
@@ -1,0 +1,20 @@
+package com.cornellappdev.android.eatery.util
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun EateryPreview(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    androidx.compose.material3.MaterialTheme {
+        Column(
+            modifier = modifier
+                .background(Color.White)
+        ) {
+            content()
+        }
+    }
+
+}


### PR DESCRIPTION
## Overview

Adds easy meal type switching to the eatery details screen

## Changes Made

- Adds eatery meal tab and updates state based on selected meal
- Add global `EateryPreview` function that sets up theming for previews.
- Add components "Calendar button" and "Eatery meal tabs"
- Also add pull request template bc it seems like we just don't have one for Eatery Android???

## Test Coverage

See videos

## Next Steps

The whole details screen should be refactored lol it's so hard to read and the documentation is bad...

## Videos

  <video src="https://github.com/user-attachments/assets/a3021cbb-32d3-46a7-af0d-86789202df20" type="video/mp4">
