### PR TITLE
Make it show Eatery tabs show even if the menu is empty

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
@@ -45,6 +46,7 @@ import androidx.compose.material.FabPosition
 import androidx.compose.material.Icon
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Report
@@ -66,6 +68,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
@@ -74,15 +77,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.compose.material.Scaffold
-import androidx.compose.ui.draw.scale
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.data.models.Eatery
+import com.cornellappdev.android.eatery.data.models.Event
 import com.cornellappdev.android.eatery.data.repositories.CoilRepository
 import com.cornellappdev.android.eatery.ui.components.comparemenus.CompareMenusBotSheet
 import com.cornellappdev.android.eatery.ui.components.comparemenus.CompareMenusFAB
@@ -115,6 +117,7 @@ import com.cornellappdev.android.eatery.util.fromOffsetToDayOfWeek
 import com.cornellappdev.android.eatery.util.toReadableFullName
 import com.valentinilk.shimmer.ShimmerBounds
 import com.valentinilk.shimmer.rememberShimmer
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.time.format.DateTimeFormatter
 
@@ -185,438 +188,438 @@ fun EateryDetailScreen(
                 }
             }
         },
-        floatingActionButtonPosition = FabPosition.End,
-        content = { paddingValues ->
-            Box(
-                modifier = Modifier
-                    .background(Color.White)
-                    .padding(paddingValues)
-            ) {
-                when (val eateryApiResponse =
-                    eateryDetailViewModel.eateryFlow.collectAsState().value) {
-                    is EateryApiResponse.Pending -> {
-                        EateryDetailLoadingScreen(shimmer)
-                    }
+        floatingActionButtonPosition = FabPosition.End
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .background(Color.White)
+                .padding(paddingValues)
+        ) {
+            when (val eateryApiResponse =
+                eateryDetailViewModel.eateryFlow.collectAsState().value) {
+                is EateryApiResponse.Pending -> {
+                    EateryDetailLoadingScreen(shimmer)
+                }
 
 
-                    is EateryApiResponse.Error -> {
-                        Text(text = "ERROR")
-                    }
+                is EateryApiResponse.Error -> {
+                    Text(text = "ERROR")
+                }
 
 
-                    is EateryApiResponse.Success -> {
-                        val eatery = eateryApiResponse.data
-                        val bitmapState =
-                            eatery.imageUrl?.let {
-                                CoilRepository.getUrlState(
-                                    it,
-                                    LocalContext.current
-                                )
-                            }
-                        val infiniteTransition = rememberInfiniteTransition()
-                        val progress by infiniteTransition.animateFloat(
-                            initialValue = 0f,
-                            targetValue = .5f,
-                            animationSpec = infiniteRepeatable(
-                                animation = tween(1000),
-                                repeatMode = RepeatMode.Reverse
+                is EateryApiResponse.Success -> {
+                    val eatery = eateryApiResponse.data
+                    val bitmapState =
+                        eatery.imageUrl?.let {
+                            CoilRepository.getUrlState(
+                                it,
+                                LocalContext.current
                             )
+                        }
+                    val infiniteTransition = rememberInfiniteTransition()
+                    val progress by infiniteTransition.animateFloat(
+                        initialValue = 0f,
+                        targetValue = .5f,
+                        animationSpec = infiniteRepeatable(
+                            animation = tween(1000),
+                            repeatMode = RepeatMode.Reverse
                         )
-                        val mealTypeIndex = remember {
-                            derivedStateOf {
-                                eatery.getTypeMeal(weekDayIndex.fromOffsetToDayOfWeek())
-                                    ?.indexOfFirst { it.first == nextEvent?.description } ?: 0
+                    )
+                    val mealTypeIndex = remember {
+                        derivedStateOf {
+                            eatery.getTypeMeal(weekDayIndex.fromOffsetToDayOfWeek())
+                                ?.indexOfFirst { it.first == nextEvent?.description } ?: 0
+                        }
+                    }
+
+
+                    ModalBottomSheetLayout(
+                        sheetState = modalBottomSheetState, sheetContent = {
+                            when (sheetContent) {
+                                BottomSheetContent.PAYMENT_METHODS_AVAILABLE -> {
+                                    PaymentMethodsAvailable(selectedPaymentMethods = paymentMethods) {
+                                        coroutineScope.launch {
+                                            modalBottomSheetState.hide()
+                                        }
+                                    }
+                                }
+
+
+                                BottomSheetContent.REPORT -> {
+                                    eatery.id?.let {
+                                        ReportBottomSheet(issue = issue,
+                                            eateryid = it,
+                                            sendReport = { issue, report, eateryid ->
+                                                eateryDetailViewModel.sendReport(
+                                                    issue,
+                                                    report,
+                                                    eateryid
+                                                )
+                                            }) {
+                                            coroutineScope.launch {
+                                                modalBottomSheetState.hide()
+                                            }
+                                        }
+                                    }
+                                }
+
+
+                                BottomSheetContent.HOURS -> {
+                                    EateryHourBottomSheet(onDismiss = {
+                                        coroutineScope.launch {
+                                            modalBottomSheetState.hide()
+                                        }
+                                    }, eatery = eatery, onReportIssue = {
+                                        sheetContent = BottomSheetContent.REPORT
+
+
+                                    })
+                                }
+
+
+                                BottomSheetContent.MENUS -> {
+                                    EateryMenusBottomSheet(
+                                        weekDayIndex = weekDayIndex,
+                                        onDismiss = {
+                                            coroutineScope.launch {
+                                                modalBottomSheetState.hide()
+                                            }
+                                        },
+                                        eatery = eatery,
+                                        onShowMenuClick = { dayIndex, mealDescription, _ ->
+                                            eateryDetailViewModel.selectEvent(
+                                                eatery,
+                                                dayIndex,
+                                                mealDescription
+                                            )
+                                            weekDayIndex = dayIndex
+                                        },
+                                        onResetClick = {
+                                            weekDayIndex = 0
+                                            eateryDetailViewModel.resetSelectedEvent()
+                                        },
+                                        mealType = mealTypeIndex.value
+                                    )
+                                }
+
+                                BottomSheetContent.COMPARE_MENUS -> {
+                                    CompareMenusBotSheet(
+                                        onDismiss = {
+                                            coroutineScope.launch {
+                                                modalBottomSheetState.hide()
+                                            }
+                                        },
+                                        onCompareMenusClick = { selectedEateriesIds ->
+                                            coroutineScope.launch {
+                                                modalBottomSheetState.hide()
+                                            }
+                                            onCompareMenusClick(selectedEateriesIds)
+                                        }
+                                    )
+                                }
+
+
+                                else -> {}
                             }
+                        }, sheetShape = RoundedCornerShape(
+                            bottomStart = 0.dp,
+                            bottomEnd = 0.dp,
+                            topStart = 12.dp,
+                            topEnd = 12.dp
+                        ), sheetElevation = 8.dp
+                    ) {
+
+
+                        paymentMethods.apply {
+                            if (eatery.paymentAcceptsCash == true) add(PaymentMethodsAvailable.CASH)
+                            if (eatery.paymentAcceptsBrbs == true) add(PaymentMethodsAvailable.BRB)
+                            if (eatery.paymentAcceptsMealSwipes == true) add(
+                                PaymentMethodsAvailable.SWIPES
+                            )
                         }
 
 
-                        ModalBottomSheetLayout(
-                            sheetState = modalBottomSheetState, sheetContent = {
-                                when (sheetContent) {
-                                    BottomSheetContent.PAYMENT_METHODS_AVAILABLE -> {
-                                        PaymentMethodsAvailable(selectedPaymentMethods = paymentMethods) {
-                                            coroutineScope.launch {
-                                                modalBottomSheetState.hide()
-                                            }
-                                        }
-                                    }
+                        val listState = rememberLazyListState()
 
 
-                                    BottomSheetContent.REPORT -> {
-                                        eatery.id?.let {
-                                            ReportBottomSheet(issue = issue,
-                                                eateryid = it,
-                                                sendReport = { issue, report, eateryid ->
-                                                    eateryDetailViewModel.sendReport(
-                                                        issue,
-                                                        report,
-                                                        eateryid
-                                                    )
-                                                }) {
-                                                coroutineScope.launch {
-                                                    modalBottomSheetState.hide()
-                                                }
-                                            }
-                                        }
-                                    }
-
-
-                                    BottomSheetContent.HOURS -> {
-                                        EateryHourBottomSheet(onDismiss = {
-                                            coroutineScope.launch {
-                                                modalBottomSheetState.hide()
-                                            }
-                                        }, eatery = eatery, onReportIssue = {
-                                            sheetContent = BottomSheetContent.REPORT
-
-
-                                        })
-                                    }
-
-
-                                    BottomSheetContent.MENUS -> {
-                                        EateryMenusBottomSheet(
-                                            weekDayIndex = weekDayIndex,
-                                            onDismiss = {
-                                                coroutineScope.launch {
-                                                    modalBottomSheetState.hide()
-                                                }
-                                            },
-                                            eatery = eatery,
-                                            onShowMenuClick = { dayIndex, mealDescription, _ ->
-                                                eateryDetailViewModel.selectEvent(
-                                                    eatery,
-                                                    dayIndex,
-                                                    mealDescription
-                                                )
-                                                weekDayIndex = dayIndex
-                                            },
-                                            onResetClick = {
-                                                weekDayIndex = 0
-                                                eateryDetailViewModel.resetSelectedEvent()
-                                            },
-                                            mealType = mealTypeIndex.value
-                                        )
-                                    }
-
-                                    BottomSheetContent.COMPARE_MENUS -> {
-                                        CompareMenusBotSheet(
-                                            onDismiss = {
-                                                coroutineScope.launch {
-                                                    modalBottomSheetState.hide()
-                                                }
-                                            },
-                                            onCompareMenusClick = { selectedEateriesIds ->
-                                                coroutineScope.launch {
-                                                    modalBottomSheetState.hide()
-                                                }
-                                                onCompareMenusClick(selectedEateriesIds)
-                                            }
-                                        )
-                                    }
-
-
-                                    else -> {}
+                        Box {
+                            val fullMenuList = mutableListOf<String>()
+                            nextEvent?.menu?.forEach { category ->
+                                category.category?.let { fullMenuList.add(it) }
+                                category.items?.forEach { item ->
+                                    item.name?.let { fullMenuList.add(it) }
                                 }
-                            }, sheetShape = RoundedCornerShape(
-                                bottomStart = 0.dp,
-                                bottomEnd = 0.dp,
-                                topStart = 12.dp,
-                                topEnd = 12.dp
-                            ), sheetElevation = 8.dp
-                        ) {
-
-
-                            paymentMethods.apply {
-                                if (eatery.paymentAcceptsCash == true) add(PaymentMethodsAvailable.CASH)
-                                if (eatery.paymentAcceptsBrbs == true) add(PaymentMethodsAvailable.BRB)
-                                if (eatery.paymentAcceptsMealSwipes == true) add(
-                                    PaymentMethodsAvailable.SWIPES
-                                )
                             }
 
 
-                            val listState = rememberLazyListState()
+                            LazyColumn(
+                                state = listState,
+                                modifier = Modifier.fillMaxSize()
+                            ) {
+                                item {
+                                    Box {
+                                        Box {
+                                            Crossfade(
+                                                targetState = bitmapState?.value,
+                                                label = "imageFade",
+                                                animationSpec = tween(250),
+                                                modifier = Modifier.alpha(if (eatery.isClosed()) .53f else 1f)
+                                            ) { apiResponse ->
+                                                when (apiResponse) {
+                                                    is EateryApiResponse.Success -> {
+                                                        Image(
+                                                            bitmap = apiResponse.data,
+                                                            modifier = Modifier
+                                                                .height(240.dp)
+                                                                .fillMaxWidth(),
+                                                            contentDescription = "",
+                                                            contentScale = ContentScale.Crop
+                                                        )
+                                                    }
 
 
-                            Box {
-                                val fullMenuList = mutableListOf<String>()
-                                nextEvent?.menu?.forEach { category ->
-                                    category.category?.let { fullMenuList.add(it) }
-                                    category.items?.forEach { item ->
-                                        item.name?.let { fullMenuList.add(it) }
+                                                    is EateryApiResponse.Pending -> {
+                                                        Image(
+                                                            bitmap = ImageBitmap(
+                                                                width = 1,
+                                                                height = 1
+                                                            ),
+                                                            modifier = Modifier
+                                                                .height(240.dp)
+                                                                .fillMaxWidth()
+                                                                .background(
+                                                                    colorInterp(
+                                                                        progress,
+                                                                        GrayOne,
+                                                                        GrayThree
+                                                                    )
+                                                                ),
+                                                            contentDescription = "",
+                                                            contentScale = ContentScale.Crop
+                                                        )
+                                                    }
+
+
+                                                    else -> {
+                                                        Image(
+                                                            modifier = Modifier
+                                                                .height(240.dp)
+                                                                .fillMaxWidth(),
+                                                            painter = painterResource(R.drawable.blank_eatery),
+                                                            contentDescription = "Eatery Image",
+                                                            contentScale = ContentScale.Crop,
+                                                        )
+                                                    }
+                                                }
+                                            }
+                                        }
+
+
+                                        Button(
+                                            onClick = { eateryDetailViewModel.toggleFavorite() },
+                                            modifier = Modifier
+                                                .align(Alignment.TopEnd)
+                                                .padding(top = 40.dp, end = 16.dp)
+                                                .size(40.dp),
+                                            contentPadding = PaddingValues(6.dp),
+                                            shape = CircleShape,
+                                            colors = ButtonDefaults.buttonColors(
+                                                backgroundColor = Color.White,
+                                            )
+                                        ) {
+                                            Icon(
+                                                imageVector = if (eateryDetailViewModel.isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                                                tint = if (eateryDetailViewModel.isFavorite) Yellow else GrayFive,
+                                                contentDescription = null
+                                            )
+                                        }
+                                        PaymentWidgets(
+                                            eatery,
+                                            modifier = Modifier
+                                                .align(Alignment.BottomEnd)
+                                                .padding(16.dp)
+                                                .height(40.dp)
+                                        ) {
+                                            sheetContent =
+                                                BottomSheetContent.PAYMENT_METHODS_AVAILABLE
+                                            coroutineScope.launch {
+                                                modalBottomSheetState.show()
+                                            }
+                                        }
                                     }
                                 }
 
 
-                                LazyColumn(
-                                    state = listState,
-                                    modifier = Modifier.fillMaxSize()
-                                ) {
-                                    item {
-                                        Box {
-                                            Box {
-                                                Crossfade(
-                                                    targetState = bitmapState?.value,
-                                                    label = "imageFade",
-                                                    animationSpec = tween(250),
-                                                    modifier = Modifier.alpha(if (eatery.isClosed()) .53f else 1f)
-                                                ) { apiResponse ->
-                                                    when (apiResponse) {
-                                                        is EateryApiResponse.Success -> {
-                                                            Image(
-                                                                bitmap = apiResponse.data,
-                                                                modifier = Modifier
-                                                                    .height(240.dp)
-                                                                    .fillMaxWidth(),
-                                                                contentDescription = "",
-                                                                contentScale = ContentScale.Crop
-                                                            )
-                                                        }
-
-
-                                                        is EateryApiResponse.Pending -> {
-                                                            Image(
-                                                                bitmap = ImageBitmap(
-                                                                    width = 1,
-                                                                    height = 1
-                                                                ),
-                                                                modifier = Modifier
-                                                                    .height(240.dp)
-                                                                    .fillMaxWidth()
-                                                                    .background(
-                                                                        colorInterp(
-                                                                            progress,
-                                                                            GrayOne,
-                                                                            GrayThree
-                                                                        )
-                                                                    ),
-                                                                contentDescription = "",
-                                                                contentScale = ContentScale.Crop
-                                                            )
-                                                        }
-
-
-                                                        else -> {
-                                                            Image(
-                                                                modifier = Modifier
-                                                                    .height(240.dp)
-                                                                    .fillMaxWidth(),
-                                                                painter = painterResource(R.drawable.blank_eatery),
-                                                                contentDescription = "Eatery Image",
-                                                                contentScale = ContentScale.Crop,
-                                                            )
-                                                        }
-                                                    }
-                                                }
-                                            }
-
-
-                                            Button(
-                                                onClick = { eateryDetailViewModel.toggleFavorite() },
-                                                modifier = Modifier
-                                                    .align(Alignment.TopEnd)
-                                                    .padding(top = 40.dp, end = 16.dp)
-                                                    .size(40.dp),
-                                                contentPadding = PaddingValues(6.dp),
-                                                shape = CircleShape,
-                                                colors = ButtonDefaults.buttonColors(
-                                                    backgroundColor = Color.White,
-                                                )
-                                            ) {
-                                                Icon(
-                                                    imageVector = if (eateryDetailViewModel.isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
-                                                    tint = if (eateryDetailViewModel.isFavorite) Yellow else GrayFive,
-                                                    contentDescription = null
-                                                )
-                                            }
-                                            PaymentWidgets(
-                                                eatery,
-                                                modifier = Modifier
-                                                    .align(Alignment.BottomEnd)
-                                                    .padding(16.dp)
-                                                    .height(40.dp)
-                                            ) {
-                                                sheetContent =
-                                                    BottomSheetContent.PAYMENT_METHODS_AVAILABLE
-                                                coroutineScope.launch {
-                                                    modalBottomSheetState.show()
-                                                }
-                                            }
-                                        }
-                                    }
-
-
-                                    item {
-                                        Text(
-                                            text = eatery.name ?: "Loading...",
-                                            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-                                            style = EateryBlueTypography.h3,
-                                        )
-                                    }
-                                    item {
-                                        Text(
-                                            text = "${eatery.location} ${if (!eatery.menuSummary.isNullOrBlank()) "· ${eatery.menuSummary}" else ""}",
-                                            modifier = Modifier.padding(start = 16.dp),
-                                            style = EateryBlueTypography.subtitle2,
-                                            color = GrayFive
-                                        )
-                                    }
-                                    item {
-                                        Row(
-                                            modifier = Modifier
-                                                .padding(top = 12.dp)
-                                                .fillMaxWidth(),
-                                            horizontalArrangement = Arrangement.SpaceEvenly
-                                        ) {
-                                            if (eatery.paymentAcceptsMealSwipes == false) {
-                                                Button(
-                                                    onClick = {
-                                                        val getAppIntent =
-                                                            context.packageManager.getLaunchIntentForPackage(
-                                                                "com.cbord.get"
-                                                            )
-                                                        if (getAppIntent != null) {
-                                                            getAppIntent.addCategory(Intent.CATEGORY_LAUNCHER)
-                                                            context.startActivity(getAppIntent)
-                                                        } else {
-                                                            val openPlayIntent =
-                                                                Intent(Intent.ACTION_VIEW).apply {
-                                                                    data = Uri.parse(
-                                                                        "https://play.google.com/store/apps/details?id=com.cbord.get"
-                                                                    )
-                                                                    setPackage("com.android.vending")
-                                                                }
-                                                            context.startActivity(openPlayIntent)
-                                                        }
-                                                    },
-                                                    shape = RoundedCornerShape(100),
-                                                    colors = ButtonDefaults.buttonColors(
-                                                        backgroundColor = EateryBlue,
-                                                        contentColor = Color.White
-                                                    )
-                                                ) {
-                                                    Icon(
-                                                        painter = painterResource(id = R.drawable.ic_android_phone),
-                                                        contentDescription = "Phone - Order Online"
-                                                    )
-                                                    Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
-                                                    Text(
-                                                        modifier = Modifier.padding(vertical = 6.dp),
-                                                        text = "Order online",
-                                                        style = EateryBlueTypography.h5,
-                                                        color = Color.White
-                                                    )
-                                                }
-                                            }
+                                item {
+                                    Text(
+                                        text = eatery.name ?: "Loading...",
+                                        modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+                                        style = EateryBlueTypography.h3,
+                                    )
+                                }
+                                item {
+                                    Text(
+                                        text = "${eatery.location} ${if (!eatery.menuSummary.isNullOrBlank()) "· ${eatery.menuSummary}" else ""}",
+                                        modifier = Modifier.padding(start = 16.dp),
+                                        style = EateryBlueTypography.subtitle2,
+                                        color = GrayFive
+                                    )
+                                }
+                                item {
+                                    Row(
+                                        modifier = Modifier
+                                            .padding(top = 12.dp)
+                                            .fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.SpaceEvenly
+                                    ) {
+                                        if (eatery.paymentAcceptsMealSwipes == false) {
                                             Button(
                                                 onClick = {
-                                                    val mapIntent =
-                                                        Intent(Intent.ACTION_VIEW).apply {
-                                                            data =
-                                                                Uri.parse("google.navigation:q=${eatery.latitude},${eatery.longitude}&mode=w")
-                                                            setPackage("com.google.android.apps.maps")
-                                                        }
-                                                    context.startActivity(mapIntent)
+                                                    val getAppIntent =
+                                                        context.packageManager.getLaunchIntentForPackage(
+                                                            "com.cbord.get"
+                                                        )
+                                                    if (getAppIntent != null) {
+                                                        getAppIntent.addCategory(Intent.CATEGORY_LAUNCHER)
+                                                        context.startActivity(getAppIntent)
+                                                    } else {
+                                                        val openPlayIntent =
+                                                            Intent(Intent.ACTION_VIEW).apply {
+                                                                data = Uri.parse(
+                                                                    "https://play.google.com/store/apps/details?id=com.cbord.get"
+                                                                )
+                                                                setPackage("com.android.vending")
+                                                            }
+                                                        context.startActivity(openPlayIntent)
+                                                    }
                                                 },
                                                 shape = RoundedCornerShape(100),
-                                                modifier = if (eatery.paymentAcceptsMealSwipes == false) Modifier else Modifier
-                                                    .fillMaxWidth()
-                                                    .padding(horizontal = 15.dp),
                                                 colors = ButtonDefaults.buttonColors(
-                                                    backgroundColor = GrayZero,
-                                                    contentColor = Color.Black
+                                                    backgroundColor = EateryBlue,
+                                                    contentColor = Color.White
                                                 )
                                             ) {
                                                 Icon(
-                                                    painter = painterResource(id = R.drawable.ic_walk),
-                                                    contentDescription = "Walk - Get Directions"
+                                                    painter = painterResource(id = R.drawable.ic_android_phone),
+                                                    contentDescription = "Phone - Order Online"
                                                 )
                                                 Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                                                 Text(
                                                     modifier = Modifier.padding(vertical = 6.dp),
-                                                    text = "Get directions",
+                                                    text = "Order online",
                                                     style = EateryBlueTypography.h5,
-                                                    maxLines = 1
+                                                    color = Color.White
                                                 )
                                             }
                                         }
-                                    }
-
-
-                                    item {
-                                        AlertsSection(eatery = eatery)
-
-
-                                        Row(
-                                            modifier = Modifier
-                                                .height(IntrinsicSize.Min)
-                                                .fillMaxWidth()
-                                                .padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
-                                                .border(
-                                                    1.dp, GrayZero, RoundedCornerShape(8.dp)
-                                                ),
-                                            horizontalArrangement = Arrangement.SpaceEvenly,
-                                            verticalAlignment = Alignment.CenterVertically
-                                        ) {
-                                            Column(
-                                                horizontalAlignment = Alignment.CenterHorizontally,
-                                                modifier = Modifier
-                                                    .padding(vertical = 12.dp)
-                                                    .weight(1f, true)
-                                                    .clickable {
-                                                        sheetContent = BottomSheetContent.HOURS
-                                                        coroutineScope.launch {
-                                                            modalBottomSheetState.show()
-                                                        }
+                                        Button(
+                                            onClick = {
+                                                val mapIntent =
+                                                    Intent(Intent.ACTION_VIEW).apply {
+                                                        data =
+                                                            Uri.parse("google.navigation:q=${eatery.latitude},${eatery.longitude}&mode=w")
+                                                        setPackage("com.google.android.apps.maps")
                                                     }
-                                            ) {
-                                                Row(
-                                                    modifier = Modifier,
-                                                    verticalAlignment = Alignment.CenterVertically
-                                                ) {
-                                                    Icon(
-                                                        imageVector = Icons.Outlined.Schedule,
-                                                        contentDescription = "Hours Icon",
-                                                        tint = GrayFive
-                                                    )
-                                                    Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
-                                                    Text(
-                                                        text = "Hours", style = TextStyle(
-                                                            fontWeight = FontWeight.SemiBold,
-                                                            fontSize = 16.sp
-                                                        ), color = GrayFive
-                                                    )
+                                                context.startActivity(mapIntent)
+                                            },
+                                            shape = RoundedCornerShape(100),
+                                            modifier = if (eatery.paymentAcceptsMealSwipes == false) Modifier else Modifier
+                                                .fillMaxWidth()
+                                                .padding(horizontal = 15.dp),
+                                            colors = ButtonDefaults.buttonColors(
+                                                backgroundColor = GrayZero,
+                                                contentColor = Color.Black
+                                            )
+                                        ) {
+                                            Icon(
+                                                painter = painterResource(id = R.drawable.ic_walk),
+                                                contentDescription = "Walk - Get Directions"
+                                            )
+                                            Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
+                                            Text(
+                                                modifier = Modifier.padding(vertical = 6.dp),
+                                                text = "Get directions",
+                                                style = EateryBlueTypography.h5,
+                                                maxLines = 1
+                                            )
+                                        }
+                                    }
+                                }
+
+
+                                item {
+                                    AlertsSection(eatery = eatery)
+
+
+                                    Row(
+                                        modifier = Modifier
+                                            .height(IntrinsicSize.Min)
+                                            .fillMaxWidth()
+                                            .padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
+                                            .border(
+                                                1.dp, GrayZero, RoundedCornerShape(8.dp)
+                                            ),
+                                        horizontalArrangement = Arrangement.SpaceEvenly,
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Column(
+                                            horizontalAlignment = Alignment.CenterHorizontally,
+                                            modifier = Modifier
+                                                .padding(vertical = 12.dp)
+                                                .weight(1f, true)
+                                                .clickable {
+                                                    sheetContent = BottomSheetContent.HOURS
+                                                    coroutineScope.launch {
+                                                        modalBottomSheetState.show()
+                                                    }
                                                 }
-                                                val openUntil = eatery.getOpenUntil()
+                                        ) {
+                                            Row(
+                                                modifier = Modifier,
+                                                verticalAlignment = Alignment.CenterVertically
+                                            ) {
+                                                Icon(
+                                                    imageVector = Icons.Outlined.Schedule,
+                                                    contentDescription = "Hours Icon",
+                                                    tint = GrayFive
+                                                )
+                                                Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                                                 Text(
-                                                    modifier = Modifier.padding(top = 2.dp),
-                                                    text =
-                                                    if (openUntil == null) "Closed"
-                                                    else if (eatery.isClosingSoon()) "Closing at $openUntil"
-                                                    else ("Open until $openUntil"),
-                                                    style = TextStyle(
+                                                    text = "Hours", style = TextStyle(
                                                         fontWeight = FontWeight.SemiBold,
                                                         fontSize = 16.sp
-                                                    ),
-                                                    color = if (openUntil == null) Red
-                                                    else if (eatery.isClosingSoon()) Yellow
-                                                    else Green
+                                                    ), color = GrayFive
                                                 )
                                             }
-
-
-                                            Divider(
-                                                color = GrayZero,
-                                                modifier = Modifier
-                                                    .align(Alignment.CenterVertically)
-                                                    .fillMaxHeight(0.5f)
-                                                    .width(1.dp)
+                                            val openUntil = eatery.getOpenUntil()
+                                            Text(
+                                                modifier = Modifier.padding(top = 2.dp),
+                                                text =
+                                                if (openUntil == null) "Closed"
+                                                else if (eatery.isClosingSoon()) "Closing at $openUntil"
+                                                else ("Open until $openUntil"),
+                                                style = TextStyle(
+                                                    fontWeight = FontWeight.SemiBold,
+                                                    fontSize = 16.sp
+                                                ),
+                                                color = if (openUntil == null) Red
+                                                else if (eatery.isClosingSoon()) Yellow
+                                                else Green
                                             )
-                                            //todo get rid of this?
+                                        }
 
 
-                                            //                            Column(
+                                        Divider(
+                                            color = GrayZero,
+                                            modifier = Modifier
+                                                .align(Alignment.CenterVertically)
+                                                .fillMaxHeight(0.5f)
+                                                .width(1.dp)
+                                        )
+                                        //todo get rid of this?
+
+
+                                        //                            Column(
 //                                horizontalAlignment = Alignment.CenterHorizontally,
 //                                modifier = Modifier
 //                                    .padding(vertical = 12.dp)
@@ -664,288 +667,241 @@ fun EateryDetailScreen(
 //
 //
 //                            }
-                                        }
-                                    }
-
-
-                                    item {
-                                        Spacer(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .height(16.dp)
-                                                .background(GrayZero)
-                                        )
-                                    }
-
-
-                                    nextEvent?.let { nextEvent ->
-                                        val hoursOnClick = {
-                                            sheetContent = BottomSheetContent.MENUS
-                                            coroutineScope.launch {
-                                                modalBottomSheetState.show()
-                                            }
-                                        }
-
-
-                                        item {
-                                            Row(
-                                                modifier = Modifier.padding(
-                                                    top = 16.dp,
-                                                    bottom = 8.dp,
-                                                    start = 16.dp,
-                                                    end = 10.dp
-                                                ),
-                                                verticalAlignment = Alignment.CenterVertically
-                                            ) {
-                                                Column(
-                                                    modifier = Modifier.weight(1f)
-                                                ) {
-                                                    Text(
-                                                        text = weekDayIndex.fromOffsetToDayOfWeek()
-                                                            .toReadableFullName(),
-                                                        style = EateryBlueTypography.h4,
-                                                    )
-                                                    if (nextEvent.startTime != null && nextEvent.endTime != null) {
-                                                        Text(
-                                                            text = "${
-                                                                nextEvent.startTime.format(
-                                                                    DateTimeFormatter.ofPattern("h:mm a")
-                                                                )
-                                                            } - ${
-                                                                nextEvent.endTime.format(
-                                                                    DateTimeFormatter.ofPattern("h:mm a")
-                                                                )
-                                                            }",
-                                                            style = EateryBlueTypography.subtitle2,
-                                                            color = GrayFive
-                                                        )
-                                                    }
-                                                }
-                                                CalendarButton(onClick = { hoursOnClick() })
-                                            }
-                                        }
-
-
-                                        nextEvent.menu?.takeIf { it.size > 0 }?.let { menu ->
-                                            item {
-                                                SearchBar(searchText = filterText,
-                                                    onSearchTextChange = {
-                                                        eateryDetailViewModel.setSearchQuery(
-                                                            it
-                                                        )
-                                                    },
-                                                    placeholderText = "Search the menu...",
-                                                    modifier = Modifier.padding(horizontal = 16.dp),
-                                                    onCancelClicked = {
-                                                        eateryDetailViewModel.setSearchQuery("")
-                                                    })
-                                                Spacer(
-                                                    modifier = Modifier
-                                                        .padding(
-                                                            start = 16.dp,
-                                                            end = 16.dp,
-                                                            top = 12.dp,
-                                                            bottom = 8.dp
-                                                        )
-                                                        .fillMaxWidth()
-                                                        .height(1.dp)
-                                                        .background(GrayZero, CircleShape)
-                                                )
-                                            }
-                                            eatery.getTypeMeal(weekDayIndex.fromOffsetToDayOfWeek())
-                                                .takeIf { it?.size?.let { s -> s > 1 } == true }
-                                                ?.map { it.first }
-                                                ?.let { mealTypes ->
-                                                    item {
-                                                        EateryMealTabs(
-                                                            meals = mealTypes,
-                                                            onSelectMeal = { selectedMeal ->
-                                                                eateryDetailViewModel.selectEvent(
-                                                                    eatery,
-                                                                    weekDayIndex,
-                                                                    mealTypes[selectedMeal]
-                                                                )
-                                                            },
-                                                            selectedMealIndex = mealTypeIndex.value
-                                                        )
-                                                    }
-                                                }
-
-
-
-
-                                            menu.forEachIndexed { categoryIndex, category ->
-                                                val filteredItems = category.items?.filter {
-                                                    it.name?.contains(filterText, true) ?: false
-                                                }
-                                                if (!filteredItems.isNullOrEmpty()) {
-                                                    item {
-                                                        Text(
-                                                            text = category.category ?: "Category",
-                                                            style = EateryBlueTypography.h5,
-                                                            modifier = Modifier.padding(
-                                                                horizontal = 16.dp,
-                                                                vertical = 12.dp
-                                                            )
-                                                        )
-                                                    }
-
-
-                                                    itemsIndexed(filteredItems) { index, menuItem ->
-                                                        Row(
-                                                            verticalAlignment = Alignment.CenterVertically,
-                                                            modifier = Modifier.padding(
-                                                                top = 12.dp,
-                                                                bottom = 12.dp,
-                                                                start = 16.dp,
-                                                                end = 16.dp
-                                                            )
-                                                        ) {
-                                                            Text(
-                                                                text = menuItem.name ?: "Item Name",
-                                                                style = EateryBlueTypography.button,
-                                                                modifier = Modifier.weight(1f)
-                                                            )
-                                                        }
-
-
-                                                        if (category.items.lastIndex != index) {
-                                                            Spacer(
-                                                                modifier = Modifier
-                                                                    .fillMaxWidth()
-                                                                    .height(1.dp)
-                                                                    .background(
-                                                                        GrayZero,
-                                                                        CircleShape
-                                                                    )
-                                                            )
-                                                        }
-                                                        if (category.items.lastIndex == index && categoryIndex != nextEvent.menu.lastIndex) {
-                                                            Divider(
-                                                                color = GrayZero,
-                                                                modifier = Modifier.height(10.dp)
-                                                            )
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-
-
-                                    }
-
-
-
-
-
-
-                                    item {
-                                        Spacer(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .height(16.dp)
-                                                .background(GrayZero)
-                                        )
-                                    }
-
-
-                                    // Report an issue button
-                                    item {
-                                        Column(
-                                            modifier = Modifier.padding(
-                                                vertical = 8.dp,
-                                                horizontal = 16.dp
-                                            )
-                                        ) {
-                                            Text(
-                                                text = "Make Eatery Better",
-                                                style = EateryBlueTypography.h5,
-                                                modifier = Modifier.padding(vertical = 8.dp)
-                                            )
-                                            Text(
-                                                text = "Help us make this info more accurate by letting us know what's wrong.",
-                                                style = EateryBlueTypography.body2,
-                                                modifier = Modifier.padding(bottom = 5.dp),
-                                                color = GrayFive
-                                            )
-
-
-                                            Spacer(Modifier.height(8.dp))
-                                            //reporting button
-                                            Button(
-                                                shape = RoundedCornerShape(24.dp),
-                                                modifier = Modifier
-                                                    .height(35.dp)
-                                                    .shadow(0.dp),
-                                                onClick = {
-                                                    sheetContent = BottomSheetContent.REPORT
-                                                    coroutineScope.launch {
-                                                        modalBottomSheetState.show()
-                                                    }
-                                                },
-                                                colors = ButtonDefaults.buttonColors(
-                                                    backgroundColor = GrayZero,
-                                                )
-                                            ) {
-                                                Icon(
-                                                    imageVector = Icons.Default.Report,
-                                                    Icons.Default.Report.name
-                                                )
-                                                Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-                                                Text(
-                                                    text = "Report an Issue",
-                                                    style = EateryBlueTypography.button,
-                                                    color = Color.Black
-                                                )
-                                            }
-
-
-                                            Spacer(Modifier.height(8.dp))
-
-
-                                        }
-                                    }
-
-
-                                    item {
-                                        Spacer(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .height(16.dp)
-                                                .background(GrayZero)
-                                        )
                                     }
                                 }
-                                AnimatedVisibility(
-                                    visible = listState.firstVisibleItemIndex >= 1,
-                                    enter = fadeIn(animationSpec = tween(100)),
-                                    exit = fadeOut(animationSpec = tween(100))
-                                ) {
-                                    Column(
+
+
+                                item {
+                                    Spacer(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .background(Color.White)
-                                            .padding(top = 48.dp, bottom = 12.dp)
-                                    ) {
-                                        EateryHeader(
-                                            eatery = eatery,
-                                            eateryDetailViewModel = eateryDetailViewModel
+                                            .height(16.dp)
+                                            .background(GrayZero)
+                                    )
+                                }
+
+                                nextEvent?.let { nextEvent ->
+                                    menuHeadingItem(weekDayIndex, nextEvent, hoursOnClick = {
+                                        sheetContent = BottomSheetContent.MENUS
+                                        coroutineScope.launch {
+                                            modalBottomSheetState.show()
+                                        }
+                                    })
+
+                                    item {
+                                        SearchBar(searchText = filterText,
+                                            onSearchTextChange = {
+                                                eateryDetailViewModel.setSearchQuery(
+                                                    it
+                                                )
+                                            },
+                                            placeholderText = "Search the menu...",
+                                            modifier = Modifier.padding(horizontal = 16.dp),
+                                            onCancelClicked = {
+                                                eateryDetailViewModel.setSearchQuery("")
+                                            })
+                                        Spacer(
+                                            modifier = Modifier
+                                                .padding(
+                                                    start = 16.dp,
+                                                    end = 16.dp,
+                                                    top = 12.dp,
+                                                    bottom = 8.dp
+                                                )
+                                                .fillMaxWidth()
+                                                .height(1.dp)
+                                                .background(GrayZero, CircleShape)
                                         )
-                                        EateryDetailsStickyHeader(
-                                            nextEvent,
-                                            eatery,
-                                            filterText,
-                                            fullMenuList,
-                                            listState,
-                                            5
-                                        ) { index ->
-                                            // The first category title has an item index of 8
-                                            // ideal is listState.animateScrollToItem(index + 8, scrollOffset = -400)
-                                            coroutineScope.launch {
-                                                listState.animateScrollToItem(
-                                                    index + 5
+                                    }
+                                    eatery.getTypeMeal(weekDayIndex.fromOffsetToDayOfWeek())
+                                        .takeIf { it?.size?.let { s -> s > 1 } == true }
+                                        ?.map { it.first }
+                                        ?.let { mealTypes ->
+                                            item {
+                                                EateryMealTabs(
+                                                    meals = mealTypes,
+                                                    onSelectMeal = { selectedMeal ->
+                                                        eateryDetailViewModel.selectEvent(
+                                                            eatery,
+                                                            weekDayIndex,
+                                                            mealTypes[selectedMeal]
+                                                        )
+                                                    },
+                                                    selectedMealIndex = mealTypeIndex.value
                                                 )
                                             }
+                                        }
+
+                                    nextEvent.menu?.forEachIndexed { categoryIndex, category ->
+                                        val filteredItems = category.items?.filter {
+                                            it.name?.contains(filterText, true) ?: false
+                                        }
+                                        if (!filteredItems.isNullOrEmpty()) {
+                                            item {
+                                                Text(
+                                                    text = category.category ?: "Category",
+                                                    style = EateryBlueTypography.h5,
+                                                    modifier = Modifier.padding(
+                                                        horizontal = 16.dp,
+                                                        vertical = 12.dp
+                                                    )
+                                                )
+                                            }
+
+
+                                            itemsIndexed(filteredItems) { index, menuItem ->
+                                                Row(
+                                                    verticalAlignment = Alignment.CenterVertically,
+                                                    modifier = Modifier.padding(
+                                                        top = 12.dp,
+                                                        bottom = 12.dp,
+                                                        start = 16.dp,
+                                                        end = 16.dp
+                                                    )
+                                                ) {
+                                                    Text(
+                                                        text = menuItem.name ?: "Item Name",
+                                                        style = EateryBlueTypography.button,
+                                                        modifier = Modifier.weight(1f)
+                                                    )
+                                                }
+
+
+                                                if (category.items.lastIndex != index) {
+                                                    Spacer(
+                                                        modifier = Modifier
+                                                            .fillMaxWidth()
+                                                            .height(1.dp)
+                                                            .background(
+                                                                GrayZero,
+                                                                CircleShape
+                                                            )
+                                                    )
+                                                }
+                                                if (category.items.lastIndex == index && categoryIndex != nextEvent.menu.lastIndex) {
+                                                    Divider(
+                                                        color = GrayZero,
+                                                        modifier = Modifier.height(10.dp)
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+
+
+                                }
+
+
+
+
+
+
+                                item {
+                                    Spacer(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .height(16.dp)
+                                            .background(GrayZero)
+                                    )
+                                }
+
+
+                                // Report an issue button
+                                item {
+                                    Column(
+                                        modifier = Modifier.padding(
+                                            vertical = 8.dp,
+                                            horizontal = 16.dp
+                                        )
+                                    ) {
+                                        Text(
+                                            text = "Make Eatery Better",
+                                            style = EateryBlueTypography.h5,
+                                            modifier = Modifier.padding(vertical = 8.dp)
+                                        )
+                                        Text(
+                                            text = "Help us make this info more accurate by letting us know what's wrong.",
+                                            style = EateryBlueTypography.body2,
+                                            modifier = Modifier.padding(bottom = 5.dp),
+                                            color = GrayFive
+                                        )
+
+
+                                        Spacer(Modifier.height(8.dp))
+                                        //reporting button
+                                        Button(
+                                            shape = RoundedCornerShape(24.dp),
+                                            modifier = Modifier
+                                                .height(35.dp)
+                                                .shadow(0.dp),
+                                            onClick = {
+                                                sheetContent = BottomSheetContent.REPORT
+                                                coroutineScope.launch {
+                                                    modalBottomSheetState.show()
+                                                }
+                                            },
+                                            colors = ButtonDefaults.buttonColors(
+                                                backgroundColor = GrayZero,
+                                            )
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.Report,
+                                                Icons.Default.Report.name
+                                            )
+                                            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                                            Text(
+                                                text = "Report an Issue",
+                                                style = EateryBlueTypography.button,
+                                                color = Color.Black
+                                            )
+                                        }
+
+
+                                        Spacer(Modifier.height(8.dp))
+
+
+                                    }
+                                }
+
+
+                                item {
+                                    Spacer(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .height(16.dp)
+                                            .background(GrayZero)
+                                    )
+                                }
+                            }
+                            AnimatedVisibility(
+                                visible = listState.firstVisibleItemIndex >= 1,
+                                enter = fadeIn(animationSpec = tween(100)),
+                                exit = fadeOut(animationSpec = tween(100))
+                            ) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(Color.White)
+                                        .padding(top = 48.dp, bottom = 12.dp)
+                                ) {
+                                    EateryHeader(
+                                        eatery = eatery,
+                                        eateryDetailViewModel = eateryDetailViewModel
+                                    )
+                                    EateryDetailsStickyHeader(
+                                        nextEvent,
+                                        eatery,
+                                        filterText,
+                                        fullMenuList,
+                                        listState,
+                                        5
+                                    ) { index ->
+                                        // The first category title has an item index of 8
+                                        // ideal is listState.animateScrollToItem(index + 8, scrollOffset = -400)
+                                        coroutineScope.launch {
+                                            listState.animateScrollToItem(
+                                                index + 5
+                                            )
                                         }
                                     }
                                 }
@@ -954,7 +910,52 @@ fun EateryDetailScreen(
                     }
                 }
             }
-        })
+        }
+    }
+}
+
+private fun LazyListScope.menuHeadingItem(
+    weekDayIndex: Int,
+    nextEvent: Event,
+    hoursOnClick: () -> Job
+) {
+    item {
+        Row(
+            modifier = Modifier.padding(
+                top = 16.dp,
+                bottom = 8.dp,
+                start = 16.dp,
+                end = 10.dp
+            ),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = weekDayIndex.fromOffsetToDayOfWeek()
+                        .toReadableFullName(),
+                    style = EateryBlueTypography.h4,
+                )
+                if (nextEvent.startTime != null && nextEvent.endTime != null) {
+                    Text(
+                        text = "${
+                            nextEvent.startTime.format(
+                                DateTimeFormatter.ofPattern("h:mm a")
+                            )
+                        } - ${
+                            nextEvent.endTime.format(
+                                DateTimeFormatter.ofPattern("h:mm a")
+                            )
+                        }",
+                        style = EateryBlueTypography.subtitle2,
+                        color = GrayFive
+                    )
+                }
+            }
+            CalendarButton(onClick = { hoursOnClick() })
+        }
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Overview

Before Eatery tabs would not show if `nextEvent.menu` was `null`. I fixed it so that they will show as long as `nextEvent` is non-null. This means the tabs don't disappear when we switch to a `null` menu.

Also abstract header to its own list item component to make `EateryDetailsScreen` slightly more readable.