### PR TITLE
Remove debug signing why tf is that there

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,6 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.debug
         }
     }
 


### PR DESCRIPTION
## Overview

Removes debug signing from the gradle on release. Why was that even ever added?