### PR TITLE
compare menus bug fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0-alpha02'
+        kotlinCompilerExtensionVersion '1.5.7'
     }
 
     packagingOptions {
@@ -114,7 +114,7 @@ dependencies {
 
     implementation "androidx.datastore:datastore:1.0.0"
     implementation "androidx.datastore:datastore-core:1.0.0"
-    implementation "com.google.protobuf:protobuf-javalite:3.21.1"
+    implementation "com.google.protobuf:protobuf-javalite:3.25.1"
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
 
@@ -134,8 +134,8 @@ dependencies {
 
     // Hilt
     // Implementation and kapt must be in-sync version number
-    implementation "com.google.dagger:hilt-android:2.44.2"
-    kapt 'com.google.dagger:hilt-compiler:2.44.2'
+    implementation "com.google.dagger:hilt-android:2.51.1"
+    kapt 'com.google.dagger:hilt-compiler:2.51.1'
     implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'
     implementation "androidx.fragment:fragment-ktx:1.5.5"
 
@@ -147,7 +147,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.20.0-rc-1"
+        artifact = "com.google.protobuf:protoc:3.25.1"
     }
 
     generateProtoTasks {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/comparemenus/CompareMenusBotSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/comparemenus/CompareMenusBotSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -27,6 +28,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -60,12 +62,17 @@ import kotlinx.coroutines.launch
 fun CompareMenusBotSheet(
     onDismiss: () -> Unit,
     onCompareMenusClick: (selectedEateriesIds: List<Int>) -> Unit,
-    compareMenusBotViewModel: CompareMenusBotViewModel = hiltViewModel()
+    compareMenusBotViewModel: CompareMenusBotViewModel = hiltViewModel(),
+    firstEatery: Eatery? = null
 ) {
     val compareMenusUIState by compareMenusBotViewModel.compareMenusUiState.collectAsState()
     val filters = compareMenusUIState.filters
     val selectedEateries = compareMenusUIState.selected
     val eateries = compareMenusUIState.eateries
+
+    LaunchedEffect(firstEatery) {
+        compareMenusBotViewModel.initializedFirstEatery(firstEatery)
+    }
 
     Column(
         modifier = Modifier
@@ -75,7 +82,8 @@ fun CompareMenusBotSheet(
         horizontalAlignment = Alignment.Start
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(
@@ -98,21 +106,26 @@ fun CompareMenusBotSheet(
                 )
             }
         }
+    }
 
-        CompareFilterRow(
-            currentFiltersSelected = filters,
-            onPaymentMethodsClicked = {},
-            onFilterClicked = { filter ->
-                if (filters.contains(filter)) {
-                    compareMenusBotViewModel.removeFilterCM(filter)
-                } else {
-                    compareMenusBotViewModel.addFilterCM(filter)
-                }
-            },
-            showPaymentFilter = false
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
+    CompareFilterRow(
+        currentFiltersSelected = filters,
+        onPaymentMethodsClicked = {},
+        onFilterClicked = { filter ->
+            if (filters.contains(filter)) {
+                compareMenusBotViewModel.removeFilterCM(filter)
+            } else {
+                compareMenusBotViewModel.addFilterCM(filter)
+            }
+        },
+        showPaymentFilter = false
+    )
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp, 10.dp, 16.dp, 16.dp),
+        horizontalAlignment = Alignment.Start
+    ) {
 
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -314,7 +314,8 @@ fun EateryDetailScreen(
                                                 modalBottomSheetState.hide()
                                             }
                                             onCompareMenusClick(selectedEateriesIds)
-                                        }
+                                        },
+                                        firstEatery = eatery
                                     )
                                 }
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/CompareMenusBotViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/CompareMenusBotViewModel.kt
@@ -65,24 +65,13 @@ class CompareMenusBotViewModel @Inject constructor(
                 is EateryApiResponse.Success -> {
                     _compareMenusUiState.update { currentState ->
                         currentState.copy(
-                            eateries = if (firstEatery != null) {
-                                (listOf(firstEatery!!) + (eateriesApiResponse.data.filter { eatery ->
-                                    eatery.name != firstEatery!!.name && filters.all { filter ->
-                                        filter.passesFilter(eatery, favorites, selected)
-                                    }
-                                }))
-                            } else {
-                                eateriesApiResponse.data.filter { eatery ->
-                                    filters.all { filter ->
-                                        filter.passesFilter(eatery, favorites, selected)
-                                    }
+                            eateries =
+                            (listOfNotNull(firstEatery) + eateriesApiResponse.data.filter { it.name != firstEatery?.name }).filter { eatery ->
+                                filters.all { filter ->
+                                    filter.passesFilter(eatery, favorites, selected)
                                 }
                             },
-                            allEateries = if (firstEatery != null) {
-                                listOf(firstEatery!!) + eateriesApiResponse.data.filter { it.name != firstEatery!!.name }
-                            } else {
-                                eateriesApiResponse.data
-                            },
+                            allEateries = listOfNotNull(firstEatery) + eateriesApiResponse.data.filter { it.name != firstEatery?.name },
                             selected = selected,
                             filters = filters,
                         )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/CompareMenusBotViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/CompareMenusBotViewModel.kt
@@ -36,6 +36,8 @@ class CompareMenusBotViewModel @Inject constructor(
     private val filtersFlow = MutableStateFlow(emptyList<Filter>())
     private val selectedEateriesFlow = MutableStateFlow(emptyList<Eatery>())
 
+    private var firstEatery: Eatery? = null
+
     val eateryFlow: StateFlow<EateryApiResponse<List<Eatery>>> =
         eateryRepository.homeEateryFlow.map { apiResponse ->
             when (apiResponse) {
@@ -63,16 +65,24 @@ class CompareMenusBotViewModel @Inject constructor(
                 is EateryApiResponse.Success -> {
                     _compareMenusUiState.update { currentState ->
                         currentState.copy(
-                            eateries = eateriesApiResponse.data.filter { eatery ->
-                                filters.all { filter ->
-                                    filter.passesFilter(
-                                        eatery,
-                                        favorites,
-                                        selected
-                                    )
+                            eateries = if (firstEatery != null) {
+                                (listOf(firstEatery!!) + (eateriesApiResponse.data.filter { eatery ->
+                                    eatery.name != firstEatery!!.name && filters.all { filter ->
+                                        filter.passesFilter(eatery, favorites, selected)
+                                    }
+                                }))
+                            } else {
+                                eateriesApiResponse.data.filter { eatery ->
+                                    filters.all { filter ->
+                                        filter.passesFilter(eatery, favorites, selected)
+                                    }
                                 }
                             },
-                            allEateries = eateriesApiResponse.data,
+                            allEateries = if (firstEatery != null) {
+                                listOf(firstEatery!!) + eateriesApiResponse.data.filter { it.name != firstEatery!!.name }
+                            } else {
+                                eateriesApiResponse.data
+                            },
                             selected = selected,
                             filters = filters,
                         )
@@ -107,8 +117,20 @@ class CompareMenusBotViewModel @Inject constructor(
     }
 
     fun addFilterCM(filter: Filter) = viewModelScope.launch {
-        filtersFlow.update {
-            it + filter
+        filtersFlow.update { filters ->
+            when (filter) {
+                Filter.NORTH ->
+                    filters.filter { it != Filter.WEST && it != Filter.CENTRAL } + filter
+
+                Filter.WEST ->
+                    filters.filter { it != Filter.NORTH && it != Filter.CENTRAL } + filter
+
+                Filter.CENTRAL ->
+                    filters.filter { it != Filter.WEST && it != Filter.NORTH } + filter
+
+                else ->
+                    filters + filter
+            }
         }
     }
 
@@ -121,4 +143,16 @@ class CompareMenusBotViewModel @Inject constructor(
     fun sendReport(issue: String, report: String, eateryid: Int?) = viewModelScope.launch {
         userRepository.sendReport(issue, report, eateryid)
     }
+
+    fun initializedFirstEatery(
+        eatery: Eatery?
+    ) {
+        firstEatery = eatery
+        if (eatery != null) {
+            selectedEateriesFlow.update {
+                it + eatery
+            }
+        }
+    }
+
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'com.android.application' version '8.1.1' apply false
     id 'com.android.library' version '8.1.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.21' apply false
     id 'com.google.gms.google-services' version '4.3.14' apply false
-    id 'com.google.protobuf' version '0.9.0' apply false
-    id 'org.jetbrains.kotlin.kapt' version '1.7.21' apply false
-    id 'com.google.dagger.hilt.android' version '2.44.2' apply false
+    id 'com.google.protobuf' version '0.9.4' apply false
+    id 'org.jetbrains.kotlin.kapt' version '1.9.21' apply false
+    id 'com.google.dagger.hilt.android' version '2.51.1' apply false
 }


### PR DESCRIPTION
addressed following bugs in the compare menus bug bash
- selecting one of North/West/Central filter now automatically de-selected the others (if any other campus filters are selected)
- bottom sheet filters lazyrow is no longer cut off due to padding
- added padding between title and filters
- transition from EateryDetailsPage to CompareMenusBottomSheet now automatically selects that eatery and displays it at the top


https://github.com/user-attachments/assets/14ea21ad-319d-4b0d-8a80-d29337ccaa91

(^idk why the eatery images aren't displays in the demo above, might be a internet issue on my end)

bugs that I wasn't able to address
- making horizontal pager less choppy; wasn't able to address because I didn't find a valid solution to fix this issue

