### PR TITLE
Change to prod endpoint on `release`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,6 @@ android {
             useSupportLibrary true
         }
 
-        buildConfigField("String", "BACKEND_URL", secretsProperties['BACKEND_URL'])
         buildConfigField("String", "GET_BACKEND_URL", secretsProperties['GET_BACKEND_URL'])
         buildConfigField("String", "SESSIONID_WEBVIEW_URL", secretsProperties['SESSIONID_WEBVIEW_URL'])
         buildConfigField("String", "CORNELL_INSTITUTION_ID", secretsProperties['CORNELL_INSTITUTION_ID'])
@@ -40,11 +39,13 @@ android {
     buildTypes {
         debug {
             resValue("bool", "FIREBASE_ANALYTICS_DEACTIVATED", "true")
+            buildConfigField("String", "BACKEND_URL", secretsProperties['BACKEND_URL'])
         }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.debug
+            buildConfigField("String", "BACKEND_URL", secretsProperties['PROD_ENDPOINT'])
         }
     }
 


### PR DESCRIPTION
## Overview

Quick change (coupled with fix to `secrets.properties`) to make prod build use prod endpoint. 

Fixes #177.

## Test Plan:

Dev endpoint currently down on `debug` build (throwing `502`). Created a `release` apk and tested it works:

![image](https://github.com/user-attachments/assets/6dd64fe8-a504-4df1-8acb-a2456a80c543)
