### PR TITLE
Fix Log Out Error

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/LoginViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/LoginViewModel.kt
@@ -114,13 +114,9 @@ class LoginViewModel @Inject constructor(
         } ?: listOf()
     }
 
-    fun onLoginPressed() {
-        updateLoginLoadingState(true)
-    }
+    fun onLoginPressed() = updateLoginLoadingState(true)
 
-    fun onLoginExited() {
-        updateLoginLoadingState(false)
-    }
+    fun onLoginExited() = updateLoginLoadingState(false)
 
     private fun updateLoginLoadingState(isLoading: Boolean) {
         val currState = _state.value


### PR DESCRIPTION
## Overview
In the original implementation, pressing the log out button would temporarily log the user out, then log them back in automatically. This PR prevents this via clearing web view cookies.
