### PR TITLE
Reload eateries on resume

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,11 +40,13 @@ android {
         debug {
             resValue("bool", "FIREBASE_ANALYTICS_DEACTIVATED", "true")
             buildConfigField("String", "BACKEND_URL", secretsProperties['BACKEND_URL'])
+            buildConfigField("boolean", "ENABLE_NOTIFICATIONS", "false")
         }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             buildConfigField("String", "BACKEND_URL", secretsProperties['PROD_ENDPOINT'])
+            buildConfigField("boolean", "ENABLE_NOTIFICATIONS", "false")
         }
     }
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.kt
@@ -34,12 +34,11 @@ class MainActivity : ComponentActivity() {
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        // Want to eventually switch over to this typography
-        androidx.compose.material3.Typography()
+        val typography = androidx.compose.material3.Typography()
         setContent {
             LockScreenOrientation()
 
-            androidx.compose.material3.MaterialTheme {
+            androidx.compose.material3.MaterialTheme(typography = typography) {
                 NavigationSetup(hasOnboarded)
             }
         }

--- a/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.cornellappdev.android.eatery.data.repositories.EateryRepository
 import com.cornellappdev.android.eatery.data.repositories.UserPreferencesRepository
 import com.cornellappdev.android.eatery.ui.navigation.NavigationSetup
 import com.cornellappdev.android.eatery.util.LockScreenOrientation
@@ -16,6 +19,12 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var userPreferences: UserPreferencesRepository
 
+    @Inject
+    lateinit var eateryRepository: EateryRepository
+    private val dataRefresher = DataRefresher(pingEateries = {
+        eateryRepository.pingEateries()
+    })
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -26,7 +35,7 @@ class MainActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         // Want to eventually switch over to this typography
-        val typography = androidx.compose.material3.Typography()
+        androidx.compose.material3.Typography()
         setContent {
             LockScreenOrientation()
 
@@ -34,5 +43,10 @@ class MainActivity : ComponentActivity() {
                 NavigationSetup(hasOnboarded)
             }
         }
+        lifecycle.addObserver(dataRefresher)
     }
+}
+
+class DataRefresher(val pingEateries: () -> Unit) : DefaultLifecycleObserver {
+    override fun onResume(owner: LifecycleOwner) = pingEateries()
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/EateryRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/EateryRepository.kt
@@ -46,6 +46,10 @@ class EateryRepository @Inject constructor(private val networkApi: NetworkApi) {
 
     init {
         // Start loading backend as soon as the app initializes.
+        pingEateries()
+    }
+
+    fun pingEateries() {
         pingAllEateries()
         pingHomeEateries()
     }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/HomeScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.cornellappdev.android.eatery.BuildConfig
 import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.data.models.Eatery
 import com.cornellappdev.android.eatery.ui.components.comparemenus.CompareMenusBotSheet
@@ -88,8 +89,6 @@ import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import com.valentinilk.shimmer.ShimmerBounds
 import com.valentinilk.shimmer.rememberShimmer
 import kotlinx.coroutines.launch
-
-private const val enableNotifs = false
 
 @OptIn(
     ExperimentalMaterialApi::class,
@@ -585,7 +584,7 @@ private fun HomeStickyHeader(
                             color = Color.White,
                             style = EateryBlueTypography.h2
                         )
-                        if (enableNotifs) {
+                        if (BuildConfig.ENABLE_NOTIFICATIONS) {
                             Icon(
                                 painter = painterResource(id = R.drawable.ic_bell),
                                 contentDescription = null,

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/HomeScreen.kt
@@ -89,6 +89,7 @@ import com.valentinilk.shimmer.ShimmerBounds
 import com.valentinilk.shimmer.rememberShimmer
 import kotlinx.coroutines.launch
 
+private const val enableNotifs = false
 
 @OptIn(
     ExperimentalMaterialApi::class,
@@ -584,15 +585,16 @@ private fun HomeStickyHeader(
                             color = Color.White,
                             style = EateryBlueTypography.h2
                         )
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_bell),
-                            contentDescription = null,
-                            tint = Color.White,
-                            modifier = Modifier.clickable {
-                                onNotificationsClick()
-                            }
-                        )
-
+                        if (enableNotifs) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_bell),
+                                contentDescription = null,
+                                tint = Color.White,
+                                modifier = Modifier.clickable {
+                                    onNotificationsClick()
+                                }
+                            )
+                        }
                     }
 
                 }


### PR DESCRIPTION
## Overview
To prevent users from seeing stale data when they resume the app, we fetch the eatery data at `onResume()`. 

Additional minor fixes:
- added field in build configurations for availability of notifications feature
- updated typography