### PR TITLE
Center favorites loading screen

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/CalendarButton.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/CalendarButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -36,11 +37,11 @@ fun CalendarButton(onClick: () -> Unit) {
     {
         Icon(
             imageVector = ImageVector.vectorResource(id = R.drawable.ic_calendar),
-            contentDescription = "Change date",
+            contentDescription = stringResource(R.string.change_date),
             modifier = Modifier.size(16.dp)
         )
 
-        Text("Change date", style = EateryBlueTypography.button)
+        Text(stringResource(R.string.change_date), style = EateryBlueTypography.button)
     }
 }
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryHourBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryHourBottomSheet.kt
@@ -25,10 +25,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.data.models.Eatery
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eatery.ui.theme.GrayFive
@@ -62,13 +64,13 @@ fun EateryHourBottomSheet(
             Row {
                 Icon(
                     imageVector = Icons.Outlined.Schedule,
-                    contentDescription = "Hours Icon",
+                    contentDescription = null,
                     tint = Color.Black,
                     modifier = Modifier.size(32.dp)
                 )
                 Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                 Text(
-                    text = "Hours",
+                    text = stringResource(R.string.hours_title),
                     style = EateryBlueTypography.h4,
                     color = Color.Black
                 )
@@ -94,10 +96,11 @@ fun EateryHourBottomSheet(
         val openUntil = eatery.getOpenUntil()
         Text(
             modifier = Modifier.padding(top = 2.dp),
-            text =
-                if (openUntil == null) "Closed"
-                else if (eatery.isClosingSoon()) "Closing at $openUntil"
-                else ("Open until $openUntil"),
+            text = when {
+                openUntil == null -> stringResource(R.string.closed)
+                eatery.isClosingSoon() -> stringResource(R.string.closing_at, openUntil)
+                else -> stringResource(R.string.open_until, openUntil)
+            },
             style = TextStyle(
                 fontWeight = FontWeight.SemiBold, fontSize = 16.sp
             ),
@@ -144,7 +147,12 @@ fun EateryHourBottomSheet(
             colors = ButtonDefaults.buttonColors(containerColor = GrayZero),
             shape = RoundedCornerShape(corner = CornerSize(24.dp)),
         ) {
-            Text("Close", color = Color.Black, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+            Text(
+                stringResource(R.string.close),
+                color = Color.Black,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold
+            )
         }
 
         Spacer(modifier = Modifier.height(12.dp))
@@ -154,7 +162,7 @@ fun EateryHourBottomSheet(
             modifier = Modifier.fillMaxWidth()
         ) {
             Text(
-                "Report an issue",
+                stringResource(R.string.report_an_issue),
                 color = Color.Black,
                 fontSize = 14.sp,
                 fontWeight = FontWeight.SemiBold

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryMenusBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryMenusBottomSheet.kt
@@ -33,11 +33,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.data.models.Eatery
 import com.cornellappdev.android.eatery.data.models.Event
 import com.cornellappdev.android.eatery.data.models.MealTime
@@ -107,7 +109,7 @@ fun EateryMenusBottomSheet(
                     modifier = Modifier.weight(1f)
                 ) {
                     Text(
-                        text = "Menus",
+                        text = stringResource(R.string.menus_title),
                         style = EateryBlueTypography.h4,
                     )
                 }
@@ -233,7 +235,7 @@ fun EateryMenusBottomSheet(
                     )
                 ) {
                     Text(
-                        text = "Show menu",
+                        text = stringResource(R.string.show_menu),
                         style = EateryBlueTypography.h5
                     )
                 }
@@ -246,7 +248,7 @@ fun EateryMenusBottomSheet(
                     }
                 ) {
                     Text(
-                        text = "Reset",
+                        text = stringResource(R.string.reset),
                         style = TextStyle(
                             fontSize = 14.sp,
                             lineHeight = 17.5.sp,

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/AppStoreRatingPopup.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/AppStoreRatingPopup.kt
@@ -37,11 +37,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.ui.components.home.EateryDetailLoadingScreen
 import com.cornellappdev.android.eatery.ui.theme.EateryBlue
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
@@ -76,8 +78,8 @@ private fun AppStoreRatingDialog(navigateToSupport: () -> Unit, onDismiss: () ->
             0 -> RatingPrompt(rating, onChangeRating = { rating = it }, onDismiss = onDismiss)
 
             5 -> ActionPrompt(
-                "Awesome! We'd love to hear more in a review",
-                "Open PlayStore",
+                stringResource(R.string.app_store_rating_positive_message),
+                stringResource(R.string.app_store_rating_positive_button),
                 onButtonPress = {
                     try {
                         context.startActivity(
@@ -101,8 +103,8 @@ private fun AppStoreRatingDialog(navigateToSupport: () -> Unit, onDismiss: () ->
             )
 
             else -> ActionPrompt(
-                "Sorry to hear that.",
-                "Visit support",
+                stringResource(R.string.app_store_rating_negative_message),
+                stringResource(R.string.app_store_rating_negative_button),
                 onButtonPress = { navigateToSupport(); onDismiss() },
                 onDismiss = onDismiss,
             )
@@ -145,7 +147,10 @@ private fun ActionPromptPreview() {
 private fun RatingPrompt(rating: Int, onChangeRating: (Int) -> Unit, onDismiss: () -> Unit) {
     AppStoreRatingCardBorder(onDismiss = onDismiss) {
         Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-            Text("How is your experience so far?", style = EateryBlueTypography.h4)
+            Text(
+                stringResource(R.string.app_store_rating_question),
+                style = EateryBlueTypography.h4
+            )
             RatingBar(rating, onChangeRating)
         }
     }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/FavoriteButton.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/FavoriteButton.kt
@@ -10,7 +10,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.ui.theme.GrayFive
 import com.cornellappdev.android.eatery.ui.theme.Yellow
 
@@ -39,6 +41,8 @@ fun FavoriteIcon(isFavorite: Boolean, modifier: Modifier = Modifier) {
         imageVector = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
         tint = if (isFavorite) Yellow else GrayFive,
         modifier = modifier,
-        contentDescription = "favorite: $isFavorite"
+        contentDescription = stringResource(
+            if (isFavorite) R.string.favorite_button_remove else R.string.favorite_button_add
+        )
     )
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/FilterRow.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/FilterRow.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.cornellappdev.android.eatery.ui.theme.GrayZero
 import com.cornellappdev.android.eatery.ui.theme.colorInterp
@@ -62,7 +61,7 @@ fun FilterButton(
     onFilterClicked: () -> Unit,
     selected: Boolean,
     text: String,
-    icon: ImageVector? = null
+    hasExpandIcon: Boolean = false
 ) {
     val progress by animateFloatAsState(
         targetValue = if (selected) 0f else 1f,
@@ -82,11 +81,11 @@ fun FilterButton(
         )
     ) {
         Text(text)
-        if (icon != null) {
+        if (hasExpandIcon) {
             Spacer(Modifier.size(ButtonDefaults.IconSpacing))
             Icon(
                 Icons.Default.ExpandMore,
-                contentDescription = "Favorite",
+                contentDescription = "Expand filters",
                 modifier = Modifier.size(ButtonDefaults.IconSize)
             )
         }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/FilterRow.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/FilterRow.kt
@@ -22,7 +22,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.ui.theme.GrayZero
 import com.cornellappdev.android.eatery.ui.theme.colorInterp
 
@@ -85,7 +87,7 @@ fun FilterButton(
             Spacer(Modifier.size(ButtonDefaults.IconSpacing))
             Icon(
                 Icons.Default.ExpandMore,
-                contentDescription = "Expand filters",
+                contentDescription = stringResource(R.string.expand_filters),
                 modifier = Modifier.size(ButtonDefaults.IconSize)
             )
         }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/NoEateryFound.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/NoEateryFound.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.ui.theme.EateryBlue
@@ -38,7 +39,7 @@ fun NoEateryFound(modifier: Modifier = Modifier, resetFilters: () -> Unit) {
             tint = GrayTwo
         )
         Text(
-            text = "No eatery found...",
+            text = stringResource(R.string.no_eatery_found),
             style = EateryBlueTypography.h5,
             modifier = Modifier.padding(top = 12.dp)
         )
@@ -53,7 +54,7 @@ fun NoEateryFound(modifier: Modifier = Modifier, resetFilters: () -> Unit) {
             }
         ) {
             Text(
-                text = "Reset filters",
+                text = stringResource(R.string.reset_filters),
                 color =
                 Color.White
             )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/PaymentMethodsAvailable.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/PaymentMethodsAvailable.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.SpanStyle
@@ -48,17 +49,18 @@ fun PaymentMethodsAvailable(
     hide: () -> Unit
 ) {
     val paymentMethodsAvailableText = buildAnnotatedString {
-        append("Pay with ")
+        append(stringResource(R.string.payment_methods_pay_with))
+        append(" ")
         if (selectedPaymentMethods.containsAll(PaymentMethodsAvailable.entries)) {
-            append("all payment methods")
+            append(stringResource(R.string.payment_methods_all))
         } else {
             selectedPaymentMethods.forEachIndexed { index, paymentMethod ->
                 appendInlineContent(id = paymentMethod.name)
                 pushStyle(SpanStyle(color = paymentMethod.color))
-                append(" ${paymentMethod.text}")
+                append(" ${stringResource(paymentMethod.textRes)}")
                 pop()
                 if (index != selectedPaymentMethods.lastIndex) {
-                    append(" or ")
+                    append(" ${stringResource(R.string.payment_methods_or)} ")
                 }
             }
         }
@@ -88,7 +90,7 @@ fun PaymentMethodsAvailable(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(
-                text = "Payment Methods",
+                text = stringResource(R.string.payment_methods_title),
                 style = EateryBlueTypography.h4,
                 modifier = Modifier.padding(bottom = 12.dp)
             )
@@ -101,7 +103,11 @@ fun PaymentMethodsAvailable(
                     .size(40.dp)
                     .background(color = GrayZero, shape = CircleShape)
             ) {
-                Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.Black)
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = stringResource(R.string.payment_methods_close),
+                    tint = Color.Black
+                )
             }
         }
 
@@ -124,7 +130,7 @@ fun PaymentMethodsAvailable(
                 ) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_payment_swipes),
-                        contentDescription = "Swipes",
+                        contentDescription = stringResource(R.string.payment_methods_meal_swipes),
                         tint = if (selectedPaymentMethods.contains(PaymentMethodsAvailable.SWIPES)) EateryBlue else GrayTwo
                     )
                 }
@@ -143,7 +149,7 @@ fun PaymentMethodsAvailable(
                 ) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_payment_brbs),
-                        contentDescription = "BRBs",
+                        contentDescription = stringResource(R.string.payment_methods_brbs),
                         tint = if (selectedPaymentMethods.contains(PaymentMethodsAvailable.BRB)) Red else GrayTwo
                     )
                 }
@@ -161,7 +167,7 @@ fun PaymentMethodsAvailable(
                 ) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_payment_cash),
-                        contentDescription = "Cash or card",
+                        contentDescription = stringResource(R.string.payment_methods_cash_or_credit),
                         tint = if (selectedPaymentMethods.contains(PaymentMethodsAvailable.CASH)) Green else GrayTwo
                     )
                 }
@@ -189,7 +195,7 @@ fun PaymentMethodsAvailable(
             )
         ) {
             Text(
-                text = "Close",
+                text = stringResource(R.string.payment_methods_close),
                 style = EateryBlueTypography.h5,
                 modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)
             )
@@ -197,8 +203,16 @@ fun PaymentMethodsAvailable(
     }
 }
 
-enum class PaymentMethodsAvailable(val drawable: Int, val color: Color, val text: String) {
-    BRB(drawable = R.drawable.ic_small_brbs, color = Red, text = "BRBs"),
-    CASH(drawable = R.drawable.ic_small_cash, color = Green, text = "Cash or credit"),
-    SWIPES(drawable = R.drawable.ic_small_swipes, color = EateryBlue, text = "Meal swipes");
+enum class PaymentMethodsAvailable(val drawable: Int, val color: Color, val textRes: Int) {
+    BRB(drawable = R.drawable.ic_small_brbs, color = Red, textRes = R.string.payment_methods_brbs),
+    CASH(
+        drawable = R.drawable.ic_small_cash,
+        color = Green,
+        textRes = R.string.payment_methods_cash_or_credit
+    ),
+    SWIPES(
+        drawable = R.drawable.ic_small_swipes,
+        color = EateryBlue,
+        textRes = R.string.payment_methods_meal_swipes
+    );
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/PaymentMethodsBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/PaymentMethodsBottomSheet.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -48,7 +49,7 @@ fun PaymentMethodsBottomSheet(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(
-                text = "Payment Methods",
+                text = stringResource(R.string.payment_methods_title),
                 style = EateryBlueTypography.h4,
                 modifier = Modifier.padding(bottom = 12.dp)
             )
@@ -61,7 +62,11 @@ fun PaymentMethodsBottomSheet(
                     .size(40.dp)
                     .background(color = GrayZero, shape = CircleShape)
             ) {
-                Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.Black)
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = stringResource(R.string.payment_methods_close),
+                    tint = Color.Black
+                )
             }
         }
 
@@ -91,13 +96,13 @@ fun PaymentMethodsBottomSheet(
                 ) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_payment_swipes),
-                        contentDescription = "Swipes",
+                        contentDescription = stringResource(R.string.payment_methods_meal_swipes),
                         tint = if (selectedFilters.contains(Filter.FromEateryFilter.Swipes)) Color.White else GrayFive
                     )
                 }
 
                 Text(
-                    text = "Meal Swipes",
+                    text = stringResource(R.string.payment_methods_meal_swipes),
                     style = TextStyle(fontWeight = FontWeight.SemiBold, fontSize = 12.sp),
                     modifier = Modifier.padding(top = 8.dp)
                 )
@@ -123,13 +128,13 @@ fun PaymentMethodsBottomSheet(
                 ) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_payment_brbs),
-                        contentDescription = "BRBs",
+                        contentDescription = stringResource(R.string.payment_methods_brbs),
                         tint = if (selectedFilters.contains(Filter.FromEateryFilter.BRB)) Color.White else GrayFive
                     )
                 }
 
                 Text(
-                    text = "BRBs",
+                    text = stringResource(R.string.payment_methods_brbs),
                     style = TextStyle(fontWeight = FontWeight.SemiBold, fontSize = 12.sp),
                     modifier = Modifier.padding(top = 8.dp)
                 )
@@ -154,13 +159,13 @@ fun PaymentMethodsBottomSheet(
                 ) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_payment_cash),
-                        contentDescription = "Cash or credit",
+                        contentDescription = stringResource(R.string.payment_methods_cash_or_credit),
                         tint = if (selectedFilters.contains(Filter.FromEateryFilter.Cash)) Color.White else GrayFive
                     )
                 }
 
                 Text(
-                    text = "Cash or credit",
+                    text = stringResource(R.string.payment_methods_cash_or_credit),
                     style = TextStyle(fontWeight = FontWeight.SemiBold, fontSize = 12.sp),
                     modifier = Modifier.padding(top = 8.dp)
                 )
@@ -179,7 +184,7 @@ fun PaymentMethodsBottomSheet(
             )
         ) {
             Text(
-                text = "Show results",
+                text = stringResource(R.string.payment_methods_show_results),
                 style = EateryBlueTypography.h5,
                 modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)
             )
@@ -195,7 +200,7 @@ fun PaymentMethodsBottomSheet(
                 .fillMaxWidth()
         ) {
             Text(
-                text = "Reset",
+                text = stringResource(R.string.payment_methods_reset),
                 style = EateryBlueTypography.h5,
                 color = Color.Black
             )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/PermissionRequestDialog.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/PermissionRequestDialog.kt
@@ -35,11 +35,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.ui.theme.EateryBlue
 import com.cornellappdev.android.eatery.util.EateryPreview
 import com.cornellappdev.android.eatery.util.LocationHandler
@@ -99,13 +101,13 @@ fun PermissionRequestDialog(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Text(
-                            text = "Location permissions are necessary to show you " +
-                                    "eateries that are the closest to you!" +
-                                    if (locationPermissionState.shouldShowRationale || !notificationFlowStatus) {
-                                        ""
-                                    } else {
-                                        "\n\nPlease click the button below to go to the settings to enable location permissions."
-                                    },
+                            text = stringResource(
+                                if (locationPermissionState.shouldShowRationale || !notificationFlowStatus) {
+                                    R.string.permission_location_message
+                                } else {
+                                    R.string.permission_location_message_with_settings
+                                }
+                            ),
                             textAlign = TextAlign.Center,
                             fontWeight = FontWeight.Medium
                         )
@@ -124,11 +126,13 @@ fun PermissionRequestDialog(
                             colors = ButtonDefaults.buttonColors(containerColor = EateryBlue),
                         ) {
                             Text(
-                                text = if (locationPermissionState.shouldShowRationale || !notificationFlowStatus) {
-                                    "Request Permission"
-                                } else {
-                                    "Open Settings"
-                                },
+                                text = stringResource(
+                                    if (locationPermissionState.shouldShowRationale || !notificationFlowStatus) {
+                                        R.string.request_permission
+                                    } else {
+                                        R.string.open_settings
+                                    }
+                                ),
                                 color = Color.White,
                             )
                         }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/SearchBar.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/SearchBar.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -33,6 +34,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eatery.ui.theme.GrayFive
 import com.cornellappdev.android.eatery.ui.theme.GrayZero
@@ -99,7 +101,7 @@ fun SearchBar(
             leadingIcon = {
                 Icon(
                     Icons.Default.Search,
-                    contentDescription = "Search",
+                    contentDescription = stringResource(R.string.search_icon),
                     tint = GrayFive
                 )
             },
@@ -128,7 +130,7 @@ fun SearchBar(
                 }
             ) {
                 Text(
-                    text = "Cancel",
+                    text = stringResource(R.string.search_cancel),
                     style = EateryBlueTypography.subtitle2,
                     color = GrayFive
                 )
@@ -143,7 +145,7 @@ fun SearchBarPreview() = EateryPreview {
     SearchBar(
         searchText = "",
         onSearchTextChange = {},
-        placeholderText = "Search the menu...",
+        placeholderText = stringResource(R.string.search_placeholder_menu),
         onCancelClicked = {}
     )
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/SearchBar.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/SearchBar.kt
@@ -101,7 +101,7 @@ fun SearchBar(
             leadingIcon = {
                 Icon(
                     Icons.Default.Search,
-                    contentDescription = stringResource(R.string.search_icon),
+                    contentDescription = stringResource(R.string.a11y_search_icon),
                     tint = GrayFive
                 )
             },

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/home/EateryHomeSection.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/home/EateryHomeSection.kt
@@ -26,8 +26,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.data.models.Eatery
 import com.cornellappdev.android.eatery.ui.components.general.EateryCard
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
@@ -120,7 +122,7 @@ private fun EateryHomeSectionHeader(
             ) {
                 Icon(
                     Icons.AutoMirrored.Filled.ArrowForward,
-                    contentDescription = "Favorites",
+                    contentDescription = stringResource(R.string.favorites_title),
                     tint = Color.Black
                 )
             }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/login/AccountPage.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/login/AccountPage.kt
@@ -362,7 +362,7 @@ private fun AccountPageHeader(
                         Icon(
                             modifier = Modifier.size(28.dp),
                             imageVector = Icons.Outlined.Settings,
-                            contentDescription = Icons.Outlined.Settings.name,
+                            contentDescription = stringResource(R.string.a11y_settings),
                             tint = Color.White
                         )
                     }
@@ -383,7 +383,7 @@ private fun AccountPageHeader(
                         Icon(
                             modifier = Modifier.size(28.dp),
                             imageVector = Icons.Outlined.Settings,
-                            contentDescription = Icons.Outlined.Settings.name,
+                            contentDescription = stringResource(R.string.a11y_settings),
                             tint = Color.White
                         )
                     }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/login/AccountPage.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/login/AccountPage.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.android.eatery.ui.components.login
 
+import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -44,6 +45,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -153,34 +155,34 @@ private fun AccountPageContent(
                 (Column(modifier = Modifier.padding(horizontal = 16.dp)) {
                     Column {
                         Text(
-                            text = "Meal Plan",
+                            text = stringResource(R.string.account_meal_plan),
                             style = EateryBlueTypography.h4,
                             modifier = Modifier.padding(top = 16.dp)
                         )
                         accountTypeBalance.mealSwipes?.let {
                             AccountBalanceRow(
-                                accountName = "Meal Swipes",
+                                accountName = stringResource(TransactionAccountType.MEAL_SWIPES.displayNameRes()),
                                 swipes = it
                             )
                         }
                         HorizontalDivider(color = GrayZero, thickness = 1.dp)
                         accountTypeBalance.brbBalance?.let {
                             AccountBalanceRow(
-                                accountName = "Big Red Bucks",
+                                accountName = stringResource(TransactionAccountType.BRBS.displayNameRes()),
                                 balance = it
                             )
                         }
                         HorizontalDivider(color = GrayZero, thickness = 1.dp)
                         accountTypeBalance.cityBucksBalance?.let {
                             AccountBalanceRow(
-                                accountName = "City Bucks",
+                                accountName = stringResource(TransactionAccountType.CITY_BUCKS.displayNameRes()),
                                 balance = it
                             )
                         }
                         HorizontalDivider(color = GrayZero, thickness = 1.dp)
                         accountTypeBalance.laundryBalance?.let {
                             AccountBalanceRow(
-                                accountName = "Laundry",
+                                accountName = stringResource(TransactionAccountType.LAUNDRY.displayNameRes()),
                                 balance = it
                             )
                         }
@@ -273,12 +275,7 @@ private fun TransactionsHeader(
                 modifier = Modifier.weight(1f)
             ) {
                 Text(
-                    text = when (accountFilter) {
-                        TransactionAccountType.MEAL_SWIPES -> "Meal Swipes"
-                        TransactionAccountType.BRBS -> "Big Red Bucks"
-                        TransactionAccountType.LAUNDRY -> "Laundry"
-                        TransactionAccountType.CITY_BUCKS -> "City Bucks"
-                    },
+                    text = stringResource(accountFilter.displayNameRes()),
                     style = EateryBlueTypography.h4
                 )
             }
@@ -293,7 +290,7 @@ private fun TransactionsHeader(
             ) {
                 Icon(
                     imageVector = Icons.Default.KeyboardArrowDown,
-                    contentDescription = "Change Account Type",
+                    contentDescription = stringResource(R.string.a11y_change_account_type),
                     modifier = Modifier
                         .size(26.dp)
                 )
@@ -303,7 +300,7 @@ private fun TransactionsHeader(
             searchText = filterText,
             onSearchTextChange = setFilterText,
             modifier = Modifier.padding(bottom = 12.dp, start = 16.dp, end = 16.dp),
-            placeholderText = "Search for transactions...",
+            placeholderText = stringResource(R.string.account_search_transactions_placeholder),
             onCancelClicked = { setFilterText("") }
         )
         HorizontalDivider(
@@ -312,7 +309,7 @@ private fun TransactionsHeader(
             modifier = Modifier.padding(horizontal = 16.dp)
         )
         Text(
-            text = "Past 30 Days",
+            text = stringResource(R.string.account_past_30_days),
             modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
             style = EateryBlueTypography.h5
         )
@@ -350,7 +347,7 @@ private fun AccountPageHeader(
                     Text(
                         modifier = Modifier.align(Alignment.Center),
                         textAlign = TextAlign.Center,
-                        text = "Account",
+                        text = stringResource(R.string.account_title),
                         color = Color.White,
                         style = TextStyle(
                             fontWeight = FontWeight.SemiBold,
@@ -396,7 +393,7 @@ private fun AccountPageHeader(
                             end = 16.dp,
                             top = 24.dp
                         ),
-                        text = "Account",
+                        text = stringResource(R.string.account_title),
                         color = Color.White,
                         style = EateryBlueTypography.h2
                     )
@@ -511,7 +508,7 @@ fun AccountTypesSelector(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(
-                text = "Payment Methods",
+                text = stringResource(R.string.payment_methods_title),
                 style = EateryBlueTypography.h4,
                 modifier = Modifier.padding(bottom = 12.dp)
             )
@@ -522,12 +519,17 @@ fun AccountTypesSelector(
                     .size(40.dp)
                     .background(color = GrayZero, shape = CircleShape)
             ) {
-                Icon(Icons.Default.Close, contentDescription = "Close", tint = Black)
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = stringResource(R.string.close),
+                    tint = Black
+                )
             }
         }
         Column {
             selectedPaymentMethod.forEachIndexed { index, account ->
                 val accountIsSelected = selected == account
+                val accountLabel = stringResource(account.displayNameRes())
                 Row(
                     modifier = Modifier
                         .height(63.dp)
@@ -539,12 +541,7 @@ fun AccountTypesSelector(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween) {
                     Text(
-                        text = when (account) {
-                            TransactionAccountType.MEAL_SWIPES -> "Meal Swipes"
-                            TransactionAccountType.BRBS -> "Big Red Bucks"
-                            TransactionAccountType.LAUNDRY -> "Laundry"
-                            TransactionAccountType.CITY_BUCKS -> "City Bucks"
-                        },
+                        text = accountLabel,
                         style = EateryBlueTypography.h5,
                         modifier = Modifier.padding(start = 16.dp)
                     )
@@ -558,7 +555,11 @@ fun AccountTypesSelector(
                             imageVector = ImageVector.vectorResource(
                                 id = if (accountIsSelected) R.drawable.ic_selected else R.drawable.ic_unselected
                             ),
-                            contentDescription = null,
+                            contentDescription = if (accountIsSelected) {
+                                stringResource(R.string.a11y_account_selected, accountLabel)
+                            } else {
+                                stringResource(R.string.a11y_account_select, accountLabel)
+                            },
                             tint = Color.Unspecified
                         )
                     }
@@ -589,7 +590,7 @@ fun AccountTypesSelector(
             ) {
                 Text(
                     modifier = Modifier.padding(vertical = 6.dp),
-                    text = "Show transactions",
+                    text = stringResource(R.string.account_show_transactions),
                     style = EateryBlueTypography.h5,
                     color = Color.White
                 )
@@ -597,3 +598,12 @@ fun AccountTypesSelector(
         }
     }
 }
+
+@StringRes
+private fun TransactionAccountType.displayNameRes(): Int = when (this) {
+    TransactionAccountType.MEAL_SWIPES -> R.string.account_type_meal_swipes
+    TransactionAccountType.BRBS -> R.string.account_type_big_red_bucks
+    TransactionAccountType.LAUNDRY -> R.string.account_type_laundry
+    TransactionAccountType.CITY_BUCKS -> R.string.account_type_city_bucks
+}
+

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/notifications/FavoriteItemRow.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/notifications/FavoriteItemRow.kt
@@ -40,7 +40,7 @@ fun FavoriteItemRow(
         Icon(
             painter = if (newNotif) painterResource(id = R.drawable.ic_new_notif_star)
             else painterResource(id = R.drawable.ic_notif_star),
-            contentDescription = stringResource(R.string.notification_star_icon),
+            contentDescription = stringResource(R.string.a11y_notification_star_icon),
             tint = Color.Unspecified,
             modifier = Modifier.padding(end = 12.dp)
         )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/notifications/FavoriteItemRow.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/notifications/FavoriteItemRow.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -39,7 +40,7 @@ fun FavoriteItemRow(
         Icon(
             painter = if (newNotif) painterResource(id = R.drawable.ic_new_notif_star)
             else painterResource(id = R.drawable.ic_notif_star),
-            contentDescription = "Notification Star Icon",
+            contentDescription = stringResource(R.string.notification_star_icon),
             tint = Color.Unspecified,
             modifier = Modifier.padding(end = 12.dp)
         )
@@ -55,7 +56,7 @@ fun FavoriteItemRow(
                     modifier = Modifier.padding(end = 10.dp)
                 )
                 Text(
-                    text = "Today",
+                    text = stringResource(R.string.today),
                     fontSize = 10.sp,
                     style = EateryBlueTypography.body1,
                     color = Color.DarkGray

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/AppIconBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/AppIconBottomSheet.kt
@@ -36,10 +36,12 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.ui.theme.EateryBlue
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eatery.ui.theme.GrayOne
@@ -61,7 +63,7 @@ fun AppIconBottomSheet(hide: () -> Unit) {
             modifier = Modifier.fillMaxWidth()
         ) {
             Text(
-                text = "App Icon",
+                text = stringResource(R.string.settings_app_icon_title),
                 style = EateryBlueTypography.h4,
                 color = Color.Black,
             )
@@ -140,7 +142,7 @@ fun AppIconBottomSheet(hide: () -> Unit) {
             )
         ) {
             Text(
-                text = "Done",
+                text = stringResource(R.string.done),
                 style = EateryBlueTypography.h5,
                 modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)
             )
@@ -157,7 +159,7 @@ fun AppIconBottomSheet(hide: () -> Unit) {
                 .fillMaxWidth()
         ) {
             Text(
-                text = "Reset",
+                text = stringResource(R.string.reset),
                 style = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.SemiBold),
                 color = if (selectedAppIcon != currentIcon) Color.Black else GrayOne
             )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/ReportBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/ReportBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.android.eatery.ui.components.settings
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -63,13 +64,13 @@ import com.cornellappdev.android.eatery.ui.viewmodels.state.NetworkUiError
 import com.cornellappdev.android.eatery.ui.viewmodels.state.ReportUiState
 import com.cornellappdev.android.eatery.util.EateryPreview
 
-enum class Issue(val option: String) {
-    ITEM("Inaccurate or missing item"),
-    PRICE("Different price than listed"),
-    HOURS("Incorrect hours"),
-    WAIT_TIMES("Inaccurate wait times"),
-    DESCRIPTION("Inaccurate description"),
-    OTHER("Other")
+enum class Issue(@param:StringRes val optionRes: Int) {
+    ITEM(R.string.report_issue_item),
+    PRICE(R.string.report_issue_price),
+    HOURS(R.string.report_issue_hours),
+    WAIT_TIMES(R.string.report_issue_wait_times),
+    DESCRIPTION(R.string.report_issue_description),
+    OTHER(R.string.report_issue_other)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -89,6 +90,8 @@ fun ReportBottomSheet(
     val isSending = reportState is ReportUiState.Sending
     val issueSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val issueEntries = Issue.entries.toTypedArray()
+    val selectedIssueLabel =
+        stringResource(selectedIssue?.optionRes ?: R.string.report_choose_option)
 
     LaunchedEffect(reportState) {
         if (reportState is ReportUiState.Success) {
@@ -186,8 +189,7 @@ fun ReportBottomSheet(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = selectedIssue?.option
-                            ?: stringResource(R.string.report_choose_option),
+                        text = selectedIssueLabel,
                         style = EateryBlueTypography.h6,
                         color = if (selectedIssue == null) GrayFive else Color.Black
                     )
@@ -268,7 +270,7 @@ fun ReportBottomSheet(
                     if (isSending || selectedIssue == null) return@Button
 
                     focusManager.clearFocus()
-                    sendReport(selectedIssue.option, textEntry.trim(), eateryId)
+                    sendReport(selectedIssueLabel, textEntry.trim(), eateryId)
                 },
                 enabled = textEntry.isNotBlank() && selectedIssue != null && !isSending,
                 colors = ButtonDefaults.buttonColors(
@@ -308,7 +310,7 @@ private fun IssueBottomSheet(items: Array<Issue>, setIssue: (Issue) -> Unit, hid
     ) {
         items.forEachIndexed { index, issue ->
             SettingsOption(
-                title = issue.option,
+                title = stringResource(issue.optionRes),
                 onClick = {
                     setIssue(issue)
                     hide()

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/ReportBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/ReportBottomSheet.kt
@@ -270,7 +270,7 @@ fun ReportBottomSheet(
                     if (isSending || selectedIssue == null) return@Button
 
                     focusManager.clearFocus()
-                    sendReport(selectedIssueLabel, textEntry.trim(), eateryId)
+                    sendReport(selectedIssue.name, textEntry.trim(), eateryId)
                 },
                 enabled = textEntry.isNotBlank() && selectedIssue != null && !isSending,
                 colors = ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/ReportBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/ReportBottomSheet.kt
@@ -43,12 +43,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.data.models.NetworkError
 import com.cornellappdev.android.eatery.ui.theme.EateryBlue
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
@@ -136,7 +138,7 @@ fun ReportBottomSheet(
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(
-                    text = "Report an Issue",
+                    text = stringResource(R.string.report_title),
                     style = EateryBlueTypography.h4,
                     color = Color.Black,
                 )
@@ -159,7 +161,7 @@ fun ReportBottomSheet(
                 }
             }
             Text(
-                text = "Type of issue",
+                text = stringResource(R.string.report_type_heading),
                 style = EateryBlueTypography.h5,
                 color = Color.Black,
                 modifier = Modifier.padding(top = 15.dp)
@@ -184,19 +186,20 @@ fun ReportBottomSheet(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = selectedIssue?.option ?: "Choose an option...",
+                        text = selectedIssue?.option
+                            ?: stringResource(R.string.report_choose_option),
                         style = EateryBlueTypography.h6,
                         color = if (selectedIssue == null) GrayFive else Color.Black
                     )
                     Icon(
                         imageVector = Icons.Default.ExpandMore,
-                        contentDescription = ""
+                        contentDescription = null
                     )
                 }
             }
 
             Text(
-                text = "Description",
+                text = stringResource(R.string.report_description_heading),
                 style = EateryBlueTypography.h5,
                 color = Color.Black,
                 modifier = Modifier.padding(top = 15.dp, bottom = 5.dp)
@@ -220,7 +223,7 @@ fun ReportBottomSheet(
                 ) {
                     if (textEntry.isEmpty()) {
                         Text(
-                            text = "Tell us what's wrong...",
+                            text = stringResource(R.string.report_description_hint),
                             style = EateryBlueTypography.h6,
                             color = GrayFive
                         )
@@ -248,7 +251,7 @@ fun ReportBottomSheet(
 
             if (reportState is ReportUiState.Error) {
                 Text(
-                    text = "Unable to send report. Please try again.",
+                    text = stringResource(R.string.report_error_unable_to_send),
                     style = EateryBlueTypography.subtitle2,
                     color = Red,
                     modifier = Modifier.padding(top = 8.dp)
@@ -281,7 +284,7 @@ fun ReportBottomSheet(
                 {
                     if (!isSending)
                         Text(
-                            text = "Submit",
+                            text = stringResource(R.string.report_submit),
                             style = EateryBlueTypography.h5,
                             color = Color.White
                         )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MealBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MealBottomSheet.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -59,7 +60,7 @@ fun MealBottomSheet(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(
-                text = "Menus",
+                text = stringResource(R.string.menus_title),
                 style = EateryBlueTypography.h4,
                 modifier = Modifier.padding(bottom = 12.dp)
             )
@@ -73,7 +74,11 @@ fun MealBottomSheet(
                     .size(40.dp)
                     .background(color = GrayZero, shape = CircleShape)
             ) {
-                Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.Black)
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = stringResource(R.string.close),
+                    tint = Color.Black
+                )
             }
         }
 
@@ -95,7 +100,7 @@ fun MealBottomSheet(
                 style = EateryBlueTypography.h5
             )
             Text(
-                text = "7:30 AM-10:30 AM",
+                text = stringResource(R.string.meal_time_breakfast),
                 modifier = Modifier.padding(start = 16.dp),
                 style = EateryBlueTypography.caption
             )
@@ -112,12 +117,12 @@ fun MealBottomSheet(
             if (currSelectedMeal.value == MealFilter.BREAKFAST) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_selected),
-                    contentDescription = "Breakfast",
+                    contentDescription = null,
                 )
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_unselected),
-                    contentDescription = "Breakfast",
+                    contentDescription = null,
                 )
             }
         }
@@ -145,7 +150,7 @@ fun MealBottomSheet(
                 style = EateryBlueTypography.h5
             )
             Text(
-                text = "10:30 AM-4:00 PM",
+                text = stringResource(R.string.meal_time_lunch),
                 modifier = Modifier.padding(start = 16.dp),
                 style = EateryBlueTypography.caption
             )
@@ -162,12 +167,12 @@ fun MealBottomSheet(
             if (currSelectedMeal.value == MealFilter.LUNCH) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_selected),
-                    contentDescription = "Lunch",
+                    contentDescription = null,
                 )
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_unselected),
-                    contentDescription = "Lunch",
+                    contentDescription = null,
                 )
             }
         }
@@ -196,7 +201,7 @@ fun MealBottomSheet(
                 style = EateryBlueTypography.h5
             )
             Text(
-                text = "5:00 PM-8:30 PM",
+                text = stringResource(R.string.meal_time_dinner),
                 modifier = Modifier.padding(start = 16.dp),
                 style = EateryBlueTypography.caption
             )
@@ -212,12 +217,12 @@ fun MealBottomSheet(
             if (currSelectedMeal.value == MealFilter.DINNER) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_selected),
-                    contentDescription = "Dinner",
+                    contentDescription = null,
                 )
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_unselected),
-                    contentDescription = "Dinner",
+                    contentDescription = null,
                 )
             }
         }
@@ -245,7 +250,7 @@ fun MealBottomSheet(
                 style = EateryBlueTypography.h5
             )
             Text(
-                text = "8:30 PM-10:30 PM",
+                text = stringResource(R.string.meal_time_late_dinner),
                 modifier = Modifier.padding(start = 16.dp),
                 style = EateryBlueTypography.caption
             )
@@ -261,12 +266,12 @@ fun MealBottomSheet(
             if (currSelectedMeal.value == MealFilter.LATE_DINNER) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_selected),
-                    contentDescription = "Late Dinner",
+                    contentDescription = null,
                 )
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_unselected),
-                    contentDescription = "Late Dinner",
+                    contentDescription = null,
                 )
             }
         }
@@ -286,7 +291,7 @@ fun MealBottomSheet(
         )
     ) {
         Text(
-            text = "Show Menu",
+            text = stringResource(R.string.show_menu),
             style = EateryBlueTypography.h5,
             modifier = Modifier.padding(top = 6.dp, bottom = 6.dp)
         )
@@ -302,7 +307,7 @@ fun MealBottomSheet(
             .fillMaxWidth()
     ) {
         Text(
-            text = "Reset",
+            text = stringResource(R.string.reset),
             style = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.SemiBold),
             color = Color.Black
         )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MealBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MealBottomSheet.kt
@@ -117,12 +117,12 @@ fun MealBottomSheet(
             if (currSelectedMeal.value == MealFilter.BREAKFAST) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_selected),
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.a11y_meal_selected_breakfast),
                 )
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_unselected),
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.a11y_meal_select_breakfast),
                 )
             }
         }
@@ -167,12 +167,12 @@ fun MealBottomSheet(
             if (currSelectedMeal.value == MealFilter.LUNCH) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_selected),
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.a11y_meal_selected_lunch),
                 )
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_unselected),
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.a11y_meal_select_lunch),
                 )
             }
         }
@@ -217,12 +217,12 @@ fun MealBottomSheet(
             if (currSelectedMeal.value == MealFilter.DINNER) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_selected),
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.a11y_meal_selected_dinner),
                 )
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_unselected),
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.a11y_meal_select_dinner),
                 )
             }
         }
@@ -266,12 +266,12 @@ fun MealBottomSheet(
             if (currSelectedMeal.value == MealFilter.LATE_DINNER) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_selected),
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.a11y_meal_selected_late_dinner),
                 )
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_unselected),
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.a11y_meal_select_late_dinner),
                 )
             }
         }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MealBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MealBottomSheet.kt
@@ -39,7 +39,7 @@ import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eatery.ui.theme.GrayZero
 
 /**
- * The pop up that shows up when users want to pick a different meal as the filter in the upcoming
+ * The pop-up that shows up when users want to pick a different meal as the filter in the upcoming
  * menu screen.
  */
 @Composable

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MenuCard.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MenuCard.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -49,7 +50,6 @@ import com.cornellappdev.android.eatery.ui.theme.GrayZero
 import com.cornellappdev.android.eatery.ui.theme.Green
 import com.cornellappdev.android.eatery.util.EateryPreview
 
-
 data class MenuCardViewState(
     val eateryId: Int,
     val menu: List<MenuCategoryViewState>,
@@ -58,16 +58,11 @@ data class MenuCardViewState(
     val eateryStatus: EateryStatus?,
 )
 
-
 data class EateryHours(
     val startTime: String,
     val endTime: String,
 )
 
-/**
- * Represents the card for each eatery that is shown in the list
- * in the upcoming menu screen
- */
 @Composable
 fun MenuCard(
     menuCardViewState: MenuCardViewState,
@@ -75,26 +70,22 @@ fun MenuCard(
     selectEatery: (eateryId: Int) -> Unit = {},
 ) = with(menuCardViewState) {
     var openDropdown by remember { mutableStateOf(false) }
+
     Card(
         elevation = CardDefaults.cardElevation(defaultElevation = 5.dp),
         shape = RoundedCornerShape(10.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         modifier = Modifier.clickable {
             openDropdown = !openDropdown
-            if (!openDropdown) {
-                onEateryCardContract()
-            }
+            if (!openDropdown) onEateryCardContract()
         }
     ) {
         Column(modifier = Modifier.padding(start = 12.dp, top = 10.dp, bottom = 5.dp)) {
             Box(modifier = Modifier.fillMaxWidth()) {
-                Text(
-                    text = menuCardViewState.name,
-                    style = EateryBlueTypography.h5,
-                )
+                Text(text = name, style = EateryBlueTypography.h5)
                 Icon(
                     imageVector = if (!openDropdown) Icons.Default.ExpandMore else Icons.Default.ExpandLess,
-                    contentDescription = "Expand menu",
+                    contentDescription = stringResource(R.string.expand_menu),
                     tint = Color.Black,
                     modifier = Modifier
                         .padding(top = 10.dp, end = 20.dp)
@@ -110,23 +101,26 @@ fun MenuCard(
                             color = it.statusColor
                         )
                         Text(
-                            text = " • ",
+                            text = " ${stringResource(R.string.bullet_separator)} ",
                             style = EateryBlueTypography.subtitle2,
                             color = GrayFive
                         )
                     }
                     eateryHours?.let {
                         Text(
-                            modifier = Modifier.padding(
-                                bottom = 8.dp
+                            modifier = Modifier.padding(bottom = 8.dp),
+                            text = stringResource(
+                                R.string.menu_time_range,
+                                it.startTime,
+                                it.endTime
                             ),
-                            text = "${it.startTime} - ${it.endTime}",
                             style = EateryBlueTypography.subtitle2,
                             color = GrayFive
                         )
                     }
                 }
             }
+
             Column(
                 modifier = Modifier
                     .animateContentSize(tween(250))
@@ -167,7 +161,6 @@ private fun EateryDetails(
                 .padding(top = 8.dp, bottom = 8.dp)
                 .clickable { selectEatery() }
         ) {
-
             Row(
                 modifier = Modifier.padding(
                     start = 12.dp,
@@ -183,7 +176,7 @@ private fun EateryDetails(
                     tint = Color.Black
                 )
                 Text(
-                    text = "View Eatery Details",
+                    text = stringResource(R.string.view_eatery_details),
                     color = Color.Black,
                     modifier = Modifier.padding(start = 8.dp),
                     fontWeight = FontWeight.Bold
@@ -191,7 +184,6 @@ private fun EateryDetails(
             }
         }
     }
-
 }
 
 @Composable
@@ -202,9 +194,7 @@ private fun EateryEventMenu(menu: List<MenuCategoryViewState>) {
             .wrapContentHeight(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Column(
-            modifier = Modifier.weight(1f),
-        ) {
+        Column(modifier = Modifier.weight(1f)) {
             menu.forEach { category ->
                 Text(
                     text = category.category,
@@ -229,15 +219,12 @@ private fun MenuItemDisplay(item: MenuItemViewState) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = item.item.name ?: "Unknown",
+            text = item.item.name ?: stringResource(R.string.unknown_item),
             style = EateryBlueTypography.caption,
             fontWeight = FontWeight.Normal
         )
         if (item.isFavorite) {
-            FavoriteIcon(
-                true,
-                modifier = Modifier.requiredSize(18.dp)
-            )
+            FavoriteIcon(true, modifier = Modifier.requiredSize(18.dp))
         }
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MenuCard.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MenuCard.kt
@@ -85,7 +85,7 @@ fun MenuCard(
                 Text(text = name, style = EateryBlueTypography.h5)
                 Icon(
                     imageVector = if (!openDropdown) Icons.Default.ExpandMore else Icons.Default.ExpandLess,
-                    contentDescription = stringResource(R.string.expand_menu),
+                    contentDescription = stringResource(R.string.a11y_expand_menu),
                     tint = Color.Black,
                     modifier = Modifier
                         .padding(top = 10.dp, end = 20.dp)

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/AboutScreen.kt
@@ -39,9 +39,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -64,19 +65,18 @@ fun AboutScreen() {
                 .fillMaxWidth()
         ) {
             Text(
-                text = "About Eatery",
+                text = stringResource(R.string.about_title),
                 color = EateryBlue,
                 style = EateryBlueTypography.h2,
                 modifier = Modifier.padding(top = 7.dp)
             )
             Text(
-                text = "Learn more about Cornell AppDev",
+                text = stringResource(R.string.about_description),
                 color = GraySix,
                 style = TextStyle(fontWeight = FontWeight.Medium, fontSize = 18.sp),
                 modifier = Modifier.padding(top = 7.dp, bottom = 24.dp)
             )
-            Row(
-                horizontalArrangement = Arrangement.Center,
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(bottom = 36.dp)
@@ -92,7 +92,7 @@ fun AboutScreen() {
                     )
 
                     Text(
-                        text = "DESIGNED AND DEVELOPED BY",
+                        text = stringResource(R.string.about_designed_and_developed_by),
                         style = EateryBlueTypography.subtitle1,
                         color = GrayFive,
                         modifier = Modifier.padding(top = 12.dp)
@@ -105,12 +105,12 @@ fun AboutScreen() {
                             .padding(top = 4.dp)
                     ) {
                         Text(
-                            text = "Cornell",
+                            text = stringResource(R.string.about_cornell),
                             style = EateryBlueTypography.h2,
                             color = Color.Black,
                         )
                         Text(
-                            text = "AppDev",
+                            text = stringResource(R.string.about_appdev),
                             style = EateryBlueTypography.h2,
                             color = Color.Black,
                         )
@@ -147,7 +147,7 @@ fun AboutScreen() {
                 Modifier.size(ButtonDefaults.IconSpacing)
             )
             Text(
-                text = "Visit our website",
+                text = stringResource(R.string.about_website_button),
                 style = EateryBlueTypography.h5,
                 modifier = Modifier.padding(start = 8.dp)
             )
@@ -259,8 +259,7 @@ fun CreditsRow(position: TeamPosition) {
         targetValue = if (scrolled) 1.0f else 0.0f,
         animationSpec = tween(250, 0, LinearEasing)
     )
-    val configuration = LocalConfiguration.current
-    val screenDensity = configuration.densityDpi / 160f
+    val screenWidth = LocalWindowInfo.current.containerSize.width.toFloat()
 
     LazyRow(
         modifier = Modifier
@@ -271,7 +270,6 @@ fun CreditsRow(position: TeamPosition) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (!scrolled) {
-            val screenWidth = configuration.screenWidthDp.toFloat() * screenDensity
             val scrollDist = ((screenWidth / 2 + (Math.random() * screenWidth)) * .65).toFloat()
             val multFactor = 50000
             coroutineScope.launch {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/CompareMenusScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/CompareMenusScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -124,7 +125,7 @@ fun CompareMenusScreen(
             horizontalArrangement = Arrangement.Center
         ) {
             Text(
-                text = "Compare Menus",
+                text = stringResource(R.string.compare_menus_title),
                 fontSize = 20.sp,
                 style = EateryBlueTypography.h5,
                 fontWeight = FontWeight(600)
@@ -285,12 +286,12 @@ private fun MenuPager(
                         ) {
                             Icon(
                                 imageVector = Icons.Outlined.Schedule,
-                                contentDescription = "Hours Icon",
+                                contentDescription = null,
                                 tint = GrayFive
                             )
                             Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                             Text(
-                                text = "Hours", style = TextStyle(
+                                text = stringResource(R.string.hours_title), style = TextStyle(
                                     fontWeight = FontWeight.SemiBold,
                                     fontSize = 16.sp
                                 ), color = GrayFive
@@ -300,10 +301,15 @@ private fun MenuPager(
                         val openUntil = eatery.getOpenUntil()
                         Text(
                             modifier = Modifier.padding(top = 2.dp),
-                            text =
-                                if (openUntil == null) "Closed"
-                                else if (eatery.isClosingSoon()) "Closing at $openUntil"
-                                else ("Open until $openUntil"),
+                            text = when {
+                                openUntil == null -> stringResource(R.string.closed)
+                                eatery.isClosingSoon() -> stringResource(
+                                    R.string.closing_at,
+                                    openUntil
+                                )
+
+                                else -> stringResource(R.string.open_until, openUntil)
+                            },
                             style = TextStyle(
                                 fontWeight = FontWeight.SemiBold,
                                 fontSize = 16.sp
@@ -415,7 +421,7 @@ private fun MenuPager(
                                         horizontalArrangement = Arrangement.Center
                                     ) {
                                         Text(
-                                            text = "Sorry, there is no menu available now.",
+                                            text = stringResource(R.string.compare_menus_no_menu),
                                             color = Color.Black,
                                             style = EateryBlueTypography.h5,
                                             modifier = Modifier.padding(start = 8.dp),
@@ -461,7 +467,7 @@ private fun MenuPager(
                                                 tint = Color.Black
                                             )
                                             Text(
-                                                text = "View Eatery Details",
+                                                text = stringResource(R.string.view_eatery_details),
                                                 color = Color.Black,
                                                 modifier = Modifier.padding(
                                                     start = 8.dp,

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -244,6 +245,10 @@ fun EateryDetailScreenContent(
 
                 is EateryDetailViewState.Loaded -> {
                     val eatery = viewState.eatery
+                    val noAppAvailableText =
+                        stringResource(R.string.no_app_available_to_open_this_link)
+                    val noMapsAppText =
+                        stringResource(R.string.no_maps_app_available_on_this_device)
                     val paymentMethods = remember(eatery) {
                         buildList {
                             if (eatery.acceptsCash()) add(PaymentMethodsAvailable.CASH)
@@ -380,7 +385,7 @@ fun EateryDetailScreenContent(
                                                         modifier = Modifier
                                                             .height(240.dp)
                                                             .fillMaxWidth(),
-                                                        contentDescription = "",
+                                                        contentDescription = null,
                                                         contentScale = ContentScale.Crop
                                                     )
                                                 }
@@ -402,7 +407,7 @@ fun EateryDetailScreenContent(
                                                                     GrayThree
                                                                 )
                                                             ),
-                                                        contentDescription = "",
+                                                        contentDescription = null,
                                                         contentScale = ContentScale.Crop
                                                     )
                                                 }
@@ -414,7 +419,7 @@ fun EateryDetailScreenContent(
                                                             .height(240.dp)
                                                             .fillMaxWidth(),
                                                         painter = painterResource(R.drawable.blank_eatery),
-                                                        contentDescription = "Eatery Image",
+                                                        contentDescription = stringResource(R.string.eatery_image),
                                                         contentScale = ContentScale.Crop,
                                                     )
                                                 }
@@ -456,14 +461,25 @@ fun EateryDetailScreenContent(
 
                             item {
                                 Text(
-                                    text = eatery.name ?: "Loading...",
+                                    text = eatery.name ?: stringResource(R.string.loading),
                                     modifier = Modifier.padding(start = 16.dp, top = 16.dp),
                                     style = EateryBlueTypography.h3,
                                 )
                             }
                             item {
                                 Text(
-                                    text = "${eatery.location} ${if (!eatery.menuSummary.isNullOrBlank()) "· ${eatery.menuSummary}" else ""}",
+                                    text = if (!eatery.menuSummary.isNullOrBlank()) {
+                                        stringResource(
+                                            R.string.eatery_detail_location_with_summary,
+                                            eatery.location.orEmpty(),
+                                            eatery.menuSummary
+                                        )
+                                    } else {
+                                        stringResource(
+                                            R.string.eatery_detail_location_only,
+                                            eatery.location.orEmpty()
+                                        )
+                                    },
                                     modifier = Modifier.padding(start = 16.dp),
                                     style = EateryBlueTypography.subtitle2,
                                     color = GrayFive
@@ -516,7 +532,7 @@ fun EateryDetailScreenContent(
                                                             )
                                                             Toast.makeText(
                                                                 context,
-                                                                "No app available to open this link.",
+                                                                noAppAvailableText,
                                                                 Toast.LENGTH_SHORT
                                                             ).show()
                                                         }
@@ -531,12 +547,12 @@ fun EateryDetailScreenContent(
                                         ) {
                                             Icon(
                                                 painter = painterResource(id = R.drawable.ic_android_phone),
-                                                contentDescription = "Phone - Order Online"
+                                                contentDescription = stringResource(R.string.phone_order_online)
                                             )
                                             Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                                             Text(
                                                 modifier = Modifier.padding(vertical = 6.dp),
-                                                text = "Order online",
+                                                text = stringResource(R.string.order_online),
                                                 style = EateryBlueTypography.h5,
                                                 color = Color.White
                                             )
@@ -568,7 +584,7 @@ fun EateryDetailScreenContent(
                                                     )
                                                     Toast.makeText(
                                                         context,
-                                                        "No maps app available on this device.",
+                                                        noMapsAppText,
                                                         Toast.LENGTH_SHORT
                                                     ).show()
                                                 }
@@ -585,12 +601,12 @@ fun EateryDetailScreenContent(
                                     ) {
                                         Icon(
                                             painter = painterResource(id = R.drawable.ic_walk),
-                                            contentDescription = "Walk - Get Directions"
+                                            contentDescription = stringResource(R.string.walk_get_directions)
                                         )
                                         Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                                         Text(
                                             modifier = Modifier.padding(vertical = 6.dp),
-                                            text = "Get directions",
+                                            text = stringResource(R.string.get_directions),
                                             style = EateryBlueTypography.h5,
                                             maxLines = 1
                                         )
@@ -626,12 +642,13 @@ fun EateryDetailScreenContent(
                                         ) {
                                             Icon(
                                                 imageVector = Icons.Outlined.Schedule,
-                                                contentDescription = "Hours Icon",
+                                                contentDescription = null,
                                                 tint = GrayFive
                                             )
                                             Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                                             Text(
-                                                text = "Hours", style = TextStyle(
+                                                text = stringResource(R.string.hours_title),
+                                                style = TextStyle(
                                                     fontWeight = FontWeight.SemiBold,
                                                     fontSize = 16.sp
                                                 ), color = GrayFive
@@ -640,10 +657,18 @@ fun EateryDetailScreenContent(
                                         val openUntil = eatery.getOpenUntil()
                                         Text(
                                             modifier = Modifier.padding(top = 2.dp),
-                                            text =
-                                                if (openUntil == null) "Closed"
-                                                else if (eatery.isClosingSoon()) "Closing at $openUntil"
-                                                else ("Open until $openUntil"),
+                                            text = when {
+                                                openUntil == null -> stringResource(R.string.closed)
+                                                eatery.isClosingSoon() -> stringResource(
+                                                    R.string.closing_at,
+                                                    openUntil
+                                                )
+
+                                                else -> stringResource(
+                                                    R.string.open_until,
+                                                    openUntil
+                                                )
+                                            },
                                             style = TextStyle(
                                                 fontWeight = FontWeight.SemiBold,
                                                 fontSize = 16.sp
@@ -685,7 +710,7 @@ fun EateryDetailScreenContent(
                                         onSearchTextChange = {
                                             onSearchQueryChange(it)
                                         },
-                                        placeholderText = "Search the menu...",
+                                        placeholderText = stringResource(R.string.search_placeholder_menu),
                                         modifier = Modifier.padding(horizontal = 16.dp),
                                         onCancelClicked = {
                                             onSearchQueryChange("")
@@ -753,12 +778,12 @@ fun EateryDetailScreenContent(
                                     )
                                 ) {
                                     Text(
-                                        text = "Make Eatery Better",
+                                        text = stringResource(R.string.make_eatery_better),
                                         style = EateryBlueTypography.h5,
                                         modifier = Modifier.padding(vertical = 8.dp)
                                     )
                                     Text(
-                                        text = "Help us make this info more accurate by letting us know what's wrong.",
+                                        text = stringResource(R.string.make_eatery_better_description),
                                         style = EateryBlueTypography.body2,
                                         modifier = Modifier.padding(bottom = 5.dp),
                                         color = GrayFive
@@ -786,7 +811,7 @@ fun EateryDetailScreenContent(
                                         )
                                         Spacer(Modifier.size(ButtonDefaults.IconSpacing))
                                         Text(
-                                            text = "Report an Issue",
+                                            text = stringResource(R.string.report_an_issue),
                                             style = EateryBlueTypography.button,
                                             color = Color.Black
                                         )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -419,7 +419,7 @@ fun EateryDetailScreenContent(
                                                             .height(240.dp)
                                                             .fillMaxWidth(),
                                                         painter = painterResource(R.drawable.blank_eatery),
-                                                        contentDescription = stringResource(R.string.eatery_image),
+                                                        contentDescription = stringResource(R.string.a11y_eatery_image),
                                                         contentScale = ContentScale.Crop,
                                                     )
                                                 }
@@ -547,7 +547,7 @@ fun EateryDetailScreenContent(
                                         ) {
                                             Icon(
                                                 painter = painterResource(id = R.drawable.ic_android_phone),
-                                                contentDescription = stringResource(R.string.phone_order_online)
+                                                contentDescription = stringResource(R.string.a11y_phone_order_online)
                                             )
                                             Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                                             Text(
@@ -601,7 +601,7 @@ fun EateryDetailScreenContent(
                                     ) {
                                         Icon(
                                             painter = painterResource(id = R.drawable.ic_walk),
-                                            contentDescription = stringResource(R.string.walk_get_directions)
+                                            contentDescription = stringResource(R.string.a11y_walk_get_directions)
                                         )
                                         Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                                         Text(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -547,7 +547,7 @@ fun EateryDetailScreenContent(
                                         ) {
                                             Icon(
                                                 painter = painterResource(id = R.drawable.ic_android_phone),
-                                                contentDescription = stringResource(R.string.a11y_phone_order_online)
+                                                contentDescription = null
                                             )
                                             Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                                             Text(
@@ -601,7 +601,7 @@ fun EateryDetailScreenContent(
                                     ) {
                                         Icon(
                                             painter = painterResource(id = R.drawable.ic_walk),
-                                            contentDescription = stringResource(R.string.a11y_walk_get_directions)
+                                            contentDescription = null
                                         )
                                         Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                                         Text(
@@ -936,7 +936,7 @@ fun EateryHeader(eatery: Eatery, isFavorite: Boolean, onFavoriteClick: () -> Uni
                 .widthIn(0.dp, 280.dp)
                 .align(Alignment.Center),
             textAlign = TextAlign.Center,
-            text = eatery.name ?: "Loading...",
+            text = eatery.name ?: stringResource(R.string.loading),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             color = Color.Black,

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -156,7 +157,7 @@ private fun FavoritesScreenContent(
 
             is FavoritesScreenViewState.Error -> {
                 // TODO we should have a better no internet display
-                EateriesEmptyState("Failed to obtain eatery data")
+                EateriesEmptyState(stringResource(R.string.favorites_load_error))
             }
 
             is FavoritesScreenViewState.Loaded -> {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
@@ -85,7 +85,7 @@ fun FavoritesScreen(
         toggleEateryFilter = favoriteViewModel::toggleEateryFilter,
         toggleItemFilter = favoriteViewModel::toggleItemFilter,
         removeFavorite = favoriteViewModel::removeFavorite,
-        removeFavoriteMenuItem = favoriteViewModel::toggleFavoriteMenuItem,
+        removeFavoriteMenuItem = favoriteViewModel::removeFavoriteMenuItem,
     )
 }
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
@@ -117,7 +117,7 @@ private fun FavoritesScreenContent(
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(id = R.drawable.ic_left_chevron),
-                    contentDescription = "Back"
+                    contentDescription = stringResource(R.string.back)
                 )
             }
             IconButton(
@@ -125,13 +125,13 @@ private fun FavoritesScreenContent(
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(id = R.drawable.ic_search),
-                    contentDescription = "Search",
+                    contentDescription = stringResource(R.string.search),
                 )
             }
 
         }
         Text(
-            text = "Favorites",
+            text = stringResource(R.string.favorites_title),
             color = EateryBlue,
             style = EateryBlueTypography.h2,
             modifier = Modifier.padding(start = 6.dp, end = 6.dp)

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -54,6 +55,8 @@ import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eatery.ui.theme.GrayTwo
 import com.cornellappdev.android.eatery.ui.viewmodels.FavoritesScreenViewState
 import com.cornellappdev.android.eatery.ui.viewmodels.FavoritesViewModel
+import com.cornellappdev.android.eatery.util.EateryPreview
+import com.cornellappdev.android.eatery.util.PreviewData
 import com.valentinilk.shimmer.ShimmerBounds
 import com.valentinilk.shimmer.rememberShimmer
 import com.valentinilk.shimmer.shimmer
@@ -65,16 +68,39 @@ fun FavoritesScreen(
     onSearchClick: () -> Unit,
     onBackClick: () -> Unit
 ) {
-    val shimmer = rememberShimmer(ShimmerBounds.View)
     val uiState = favoriteViewModel.uiState.collectAsStateWithLifecycle().value
-    val favoritesScreenViewState = uiState.screenState
-    var toggle by remember { mutableStateOf(true) }
 
     // TODO: replace with an actual error state
     NetworkErrorToast(
         error = uiState.error,
         onErrorShown = favoriteViewModel::clearError
     )
+
+    FavoritesScreenContent(
+        favoritesScreenViewState = uiState.screenState,
+        onEateryClick = onEateryClick,
+        onSearchClick = onSearchClick,
+        onBackClick = onBackClick,
+        toggleEateryFilter = favoriteViewModel::toggleEateryFilter,
+        toggleItemFilter = favoriteViewModel::toggleItemFilter,
+        removeFavorite = favoriteViewModel::removeFavorite,
+        removeFavoriteMenuItem = favoriteViewModel::toggleFavoriteMenuItem,
+    )
+}
+
+@Composable
+private fun FavoritesScreenContent(
+    favoritesScreenViewState: FavoritesScreenViewState,
+    onEateryClick: (eatery: Eatery) -> Unit,
+    onSearchClick: () -> Unit,
+    onBackClick: () -> Unit,
+    toggleEateryFilter: (filter: Filter.FromEateryFilter) -> Unit,
+    toggleItemFilter: (filter: Filter) -> Unit,
+    removeFavorite: (eateryId: Int, eateryName: String) -> Unit,
+    removeFavoriteMenuItem: (menuItem: String) -> Unit,
+) {
+    val shimmer = rememberShimmer(ShimmerBounds.View)
+    var toggle by remember { mutableStateOf(true) }
 
     Column(
         modifier = Modifier
@@ -115,7 +141,9 @@ fun FavoritesScreen(
         when (favoritesScreenViewState) {
             is FavoritesScreenViewState.Loading -> {
                 LazyColumn(
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     items(15) {
                         EateryBlob(
@@ -128,7 +156,7 @@ fun FavoritesScreen(
 
             is FavoritesScreenViewState.Error -> {
                 // TODO we should have a better no internet display
-                EateriesEmptyState("Failed to obtain Eatery data")
+                EateriesEmptyState("Failed to obtain eatery data")
             }
 
             is FavoritesScreenViewState.Loaded -> {
@@ -139,14 +167,67 @@ fun FavoritesScreen(
                     favoritesScreenViewState,
                     favoriteEateries,
                     onEateryClick,
-                    toggleEateryFilter = favoriteViewModel::toggleEateryFilter,
-                    toggleItemFilter = favoriteViewModel::toggleItemFilter,
-                    removeFavorite = favoriteViewModel::removeFavorite,
-                    removeFavoriteMenuItem = favoriteViewModel::toggleFavoriteMenuItem,
+                    toggleEateryFilter = toggleEateryFilter,
+                    toggleItemFilter = toggleItemFilter,
+                    removeFavorite = removeFavorite,
+                    removeFavoriteMenuItem = removeFavoriteMenuItem,
                 )
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FavoritesScreenLoadingPreview() = EateryPreview {
+    FavoritesScreenContent(
+        favoritesScreenViewState = FavoritesScreenViewState.Loading,
+        onEateryClick = {},
+        onSearchClick = {},
+        onBackClick = {},
+        toggleEateryFilter = {},
+        toggleItemFilter = {},
+        removeFavorite = { _, _ -> },
+        removeFavoriteMenuItem = {},
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FavoritesScreenLoadedPreview() = EateryPreview {
+    FavoritesScreenContent(
+        favoritesScreenViewState = FavoritesScreenViewState.Loaded(
+            eateries = listOf(
+                PreviewData.mockEatery(1).copy(name = "Okenshields"),
+                PreviewData.mockEatery(2).copy(name = "Becker House Dining Room")
+            ),
+            favoriteCards = emptyList(),
+            selectedEateryFilters = emptyList(),
+            selectedItemFilters = emptyList(),
+        ),
+        onEateryClick = {},
+        onSearchClick = {},
+        onBackClick = {},
+        toggleEateryFilter = {},
+        toggleItemFilter = {},
+        removeFavorite = { _, _ -> },
+        removeFavoriteMenuItem = {},
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FavoritesScreenErrorPreview() = EateryPreview {
+    FavoritesScreenContent(
+        favoritesScreenViewState = FavoritesScreenViewState.Error,
+        onEateryClick = {},
+        onSearchClick = {},
+        onBackClick = {},
+        toggleEateryFilter = {},
+        toggleItemFilter = {},
+        removeFavorite = { _, _ -> },
+        removeFavoriteMenuItem = {},
+    )
 }
 
 @Composable
@@ -287,7 +368,7 @@ private fun EateryBlob(
 ) {
     Surface(
         modifier = Modifier
-            .padding(end = 12.dp)
+            .padding(horizontal = 6.dp)
             .then(modifier)
             .clip(
                 RoundedCornerShape(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/HomeScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -456,13 +457,13 @@ fun ErrorContent(onTryAgain: () -> Unit) {
     ) {
         Icon(
             painter = painterResource(R.drawable.ic_error),
-            contentDescription = "Error Icon",
+            contentDescription = stringResource(R.string.home_error_icon_desc),
             modifier = Modifier.size(72.dp),
             tint = Color.Red
         )
         Spacer(modifier = Modifier.height(12.dp))
         Text(
-            text = "Hmm, no chow here (yet).",
+            text = stringResource(R.string.home_error_title),
             fontSize = 20.sp,
             fontWeight = FontWeight.SemiBold,
             color = Color(0xFF1B1F23),
@@ -470,7 +471,7 @@ fun ErrorContent(onTryAgain: () -> Unit) {
         )
         Spacer(modifier = Modifier.height(4.dp))
         Text(
-            text = "We ran into an issue loading this page. Check your connection or try reloading the page.",
+            text = stringResource(R.string.home_error_description),
             fontSize = 18.sp,
             fontWeight = FontWeight.Normal,
             color = Color(0xFF1B1F23),
@@ -486,7 +487,7 @@ fun ErrorContent(onTryAgain: () -> Unit) {
             colors = ButtonDefaults.buttonColors(containerColor = EateryBlue)
         ) {
             Text(
-                text = "Try Again", color = Color.White,
+                text = stringResource(R.string.home_error_try_again), color = Color.White,
                 fontSize = 14.sp, fontWeight = FontWeight.SemiBold,
                 textAlign = TextAlign.Center,
                 lineHeight = 1.25.em
@@ -558,7 +559,7 @@ private fun LazyListScope.regularContent(
             val showFake = favorites.isEmpty() && lastFavorite != null
 
             EateryHomeSection(
-                title = "Favorites",
+                title = stringResource(R.string.favorites_title),
                 eateries = favorites,
                 overflowEatery = if (showFake) lastFavorite else null,
                 onEateryClick = onEateryClick,
@@ -577,7 +578,7 @@ private fun LazyListScope.regularContent(
                 Text(
                     modifier = Modifier
                         .padding(start = 16.dp, bottom = 12.dp),
-                    text = "All Eateries",
+                    text = stringResource(R.string.all_eateries_title),
                     style = EateryBlueTypography.h4,
                 )
                 Row(
@@ -587,13 +588,13 @@ private fun LazyListScope.regularContent(
                 ) {
                     Icon(
                         painter = painterResource(id = if (isGridView) R.drawable.ic_list_view_unselected else R.drawable.ic_list_view_selected),
-                        contentDescription = "List View",
+                        contentDescription = stringResource(R.string.list_view),
                         tint = Color.Unspecified,
                         modifier = Modifier.clickable { onListClick() }
                     )
                     Icon(
                         painter = painterResource(id = if (isGridView) R.drawable.ic_grid_view_selected else R.drawable.ic_grid_view_unselected),
-                        contentDescription = "Grid View",
+                        contentDescription = stringResource(R.string.grid_view),
                         tint = Color.Unspecified,
                         modifier = Modifier.clickable { onGridClick() }
                     )
@@ -684,7 +685,7 @@ private fun HomeStickyHeader(
                     Text(
                         modifier = Modifier.align(Alignment.Center),
                         textAlign = TextAlign.Center,
-                        text = "Eatery",
+                        text = stringResource(R.string.onboarding_eatery_title),
                         color = Color.White,
                         style = TextStyle(
                             fontWeight = FontWeight.SemiBold,
@@ -729,7 +730,7 @@ private fun HomeStickyHeader(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = "Eatery",
+                            text = stringResource(R.string.onboarding_eatery_title),
                             color = Color.White,
                             style = EateryBlueTypography.h2
                         )
@@ -761,7 +762,7 @@ private fun HomeMainHeader(
     SearchBar(
         searchText = "",
         onSearchTextChange = { },
-        placeholderText = "Search for grub...",
+        placeholderText = stringResource(R.string.search_placeholder_grub),
         modifier = Modifier
             .padding(horizontal = 16.dp)
             .padding(top = 12.dp, bottom = 6.dp)

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/HomeScreen.kt
@@ -457,7 +457,7 @@ fun ErrorContent(onTryAgain: () -> Unit) {
     ) {
         Icon(
             painter = painterResource(R.drawable.ic_error),
-            contentDescription = stringResource(R.string.home_error_icon_desc),
+            contentDescription = stringResource(R.string.a11y_home_error_icon_desc),
             modifier = Modifier.size(72.dp),
             tint = Color.Red
         )
@@ -588,13 +588,13 @@ private fun LazyListScope.regularContent(
                 ) {
                     Icon(
                         painter = painterResource(id = if (isGridView) R.drawable.ic_list_view_unselected else R.drawable.ic_list_view_selected),
-                        contentDescription = stringResource(R.string.list_view),
+                        contentDescription = stringResource(R.string.a11y_list_view),
                         tint = Color.Unspecified,
                         modifier = Modifier.clickable { onListClick() }
                     )
                     Icon(
                         painter = painterResource(id = if (isGridView) R.drawable.ic_grid_view_selected else R.drawable.ic_grid_view_unselected),
-                        contentDescription = stringResource(R.string.grid_view),
+                        contentDescription = stringResource(R.string.a11y_grid_view),
                         tint = Color.Unspecified,
                         modifier = Modifier.clickable { onGridClick() }
                     )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/LegalScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/LegalScreen.kt
@@ -10,10 +10,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.ui.components.settings.SettingsLineSeparator
 import com.cornellappdev.android.eatery.ui.components.settings.SettingsOption
 import com.cornellappdev.android.eatery.ui.theme.EateryBlue
@@ -29,20 +31,20 @@ fun LegalScreen() {
             .fillMaxSize()
     ) {
         Text(
-            text = "Legal",
+            text = stringResource(R.string.legal_title),
             color = EateryBlue,
             style = EateryBlueTypography.h2,
             modifier = Modifier.padding(top = 7.dp)
         )
         Text(
-            text = "Find terms, conditions, and privacy policy",
+            text = stringResource(R.string.legal_description),
             style = TextStyle(fontWeight = FontWeight.Medium, fontSize = 18.sp),
             color = GraySix,
             modifier = Modifier.padding(top = 7.dp, bottom = 12.dp)
         )
 
         SettingsOption(
-            title = "Terms and Conditions",
+            title = stringResource(R.string.legal_terms_and_conditions),
             onClick = { uriCurrent.openUri("https://www.cornellappdev.com/privacy") },
             trailingIcon = {
                 Icon(
@@ -54,7 +56,7 @@ fun LegalScreen() {
         )
         SettingsLineSeparator()
         SettingsOption(
-            title = "Privacy Policy",
+            title = stringResource(R.string.legal_privacy_policy),
             onClick = { uriCurrent.openUri("https://www.cornellappdev.com/privacy") },
             trailingIcon = {
                 Icon(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NearestScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NearestScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -54,7 +55,7 @@ fun NearestScreen(
             .fillMaxSize()
     ) {
         Text(
-            text = "Nearest to You",
+            text = stringResource(R.string.nearest_title),
             color = EateryBlue,
             style = EateryBlueTypography.h2,
             modifier = Modifier.padding(top = 7.dp)
@@ -84,7 +85,7 @@ fun NearestScreen(
                     )
 
                     Text(
-                        text = "You currently have no favorite eateries!",
+                        text = stringResource(R.string.nearest_empty_message),
                         style = TextStyle(
                             fontWeight = FontWeight.Medium,
                             fontSize = 18.sp

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NotificationsHomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NotificationsHomeScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.ui.components.notifications.FavoriteItemRow
 import com.cornellappdev.android.eatery.ui.theme.EateryBlue
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
@@ -22,13 +24,13 @@ fun NotificationsHomeScreen(
             .fillMaxSize()
     ) {
         Text(
-            text = "Notifications",
+            text = stringResource(R.string.notifications_home_title),
             color = EateryBlue,
             style = EateryBlueTypography.h2,
             modifier = Modifier.padding(top = 7.dp, bottom = 20.dp)
         )
         Text(
-            text = "Favorite Items",
+            text = stringResource(R.string.notifications_home_favorite_items),
             style = EateryBlueTypography.h4,
             modifier = Modifier.padding(bottom = 20.dp)
         )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NotificationsSettingsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NotificationsSettingsScreen.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.ui.components.settings.SwitchOption
 import com.cornellappdev.android.eatery.ui.theme.EateryBlue
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
@@ -26,21 +28,21 @@ fun NotificationsSettingsScreen() {
             .fillMaxSize()
     ) {
         Text(
-            text = "Notifications",
+            text = stringResource(R.string.notifications_title),
             color = EateryBlue,
             style = EateryBlueTypography.h2,
             modifier = Modifier.padding(top = 7.dp)
         )
 
         Text(
-            text = "Manage item and promotional notifications",
+            text = stringResource(R.string.notifications_description),
             style = TextStyle(fontWeight = FontWeight.Medium, fontSize = 18.sp),
             color = GraySix,
             modifier = Modifier.padding(top = 7.dp, bottom = 12.dp)
         )
 
         SwitchOption(
-            title = "All Notifications",
+            title = stringResource(R.string.notifications_all_title),
             description = "",
             initialValue = true,
             onCheckedChange = {
@@ -53,8 +55,8 @@ fun NotificationsSettingsScreen() {
         Spacer(modifier = Modifier.height(12.dp))
 
         SwitchOption(
-            title = "Favorite item being served",
-            description = "Get notified when favorite items are served",
+            title = stringResource(R.string.notifications_favorite_item_title),
+            description = stringResource(R.string.notifications_favorite_item_description),
             initialValue = true,
             onCheckedChange = {
 //                TODO()
@@ -62,8 +64,8 @@ fun NotificationsSettingsScreen() {
         )
 
         SwitchOption(
-            title = "Favorite eatery opening",
-            description = "Get notified when your favorite eatery opens",
+            title = stringResource(R.string.notifications_favorite_eatery_open_title),
+            description = stringResource(R.string.notifications_favorite_eatery_open_description),
             initialValue = true,
             onCheckedChange = {
 //                TODO()
@@ -71,8 +73,8 @@ fun NotificationsSettingsScreen() {
         )
 
         SwitchOption(
-            title = "Favorite eatery closing",
-            description = "Get notified when your favorite eatery closes",
+            title = stringResource(R.string.notifications_favorite_eatery_close_title),
+            description = stringResource(R.string.notifications_favorite_eatery_close_description),
             initialValue = true,
             onCheckedChange = {
 //                TODO()

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/OnboardingScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/OnboardingScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -66,6 +67,8 @@ fun OnboardingScreenContent(
     val pagerState = rememberPagerState(pageCount = { 2 })
     val coroutineScope = rememberCoroutineScope()
     var fadePage by rememberSaveable { mutableStateOf(false) }
+    val cornell = stringResource(R.string.onboarding_cornell)
+    val appdev = stringResource(R.string.onboarding_appdev)
     Box(modifier = Modifier.fillMaxSize()) {
         HorizontalPager(
             state = pagerState,
@@ -91,7 +94,7 @@ fun OnboardingScreenContent(
                         )
 
                         Text(
-                            text = "Eatery",
+                            text = stringResource(R.string.onboarding_eatery_title),
                             color = EateryBlue,
                             style = EateryBlueTypography.h1
                         )
@@ -119,7 +122,7 @@ fun OnboardingScreenContent(
                         ) {
                             Text(
                                 style = EateryBlueTypography.h6,
-                                text = "Get Started",
+                                text = stringResource(R.string.onboarding_get_started),
                                 color = Black
                             )
                         }
@@ -147,7 +150,7 @@ fun OnboardingScreenContent(
                                             fontWeight = FontWeight.Normal
                                         )
                                     ) {
-                                        append("Cornell")
+                                        append(cornell)
                                     }
                                     withStyle(
                                         style = SpanStyle(
@@ -155,7 +158,7 @@ fun OnboardingScreenContent(
                                             fontWeight = FontWeight.SemiBold
                                         )
                                     ) {
-                                        append("AppDev")
+                                        append(appdev)
                                     }
                                 }
                             )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/PrivacyScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/PrivacyScreen.kt
@@ -14,11 +14,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.ui.components.settings.SettingsLineSeparator
 import com.cornellappdev.android.eatery.ui.components.settings.SettingsOption
 import com.cornellappdev.android.eatery.ui.components.settings.SwitchOption
@@ -39,25 +41,25 @@ fun PrivacyScreen(privacyViewModel: PrivacyViewModel = hiltViewModel()) {
             .fillMaxSize()
     ) {
         Text(
-            text = "Privacy",
+            text = stringResource(R.string.privacy_title),
             color = EateryBlue,
             style = EateryBlueTypography.h2,
             modifier = Modifier.padding(top = 7.dp)
         )
         Text(
-            text = "Manage permissions and analytics",
+            text = stringResource(R.string.privacy_description),
             style = TextStyle(fontWeight = FontWeight.Medium, fontSize = 18.sp),
             color = GraySix,
             modifier = Modifier.padding(top = 7.dp, bottom = 24.dp)
         )
         Text(
-            text = "Permissions",
+            text = stringResource(R.string.privacy_permissions_heading),
             color = Color.Black,
             style = EateryBlueTypography.h4,
         )
         SettingsOption(
-            title = "Location Access",
-            description = "Used to find eateries near you",
+            title = stringResource(R.string.privacy_location_access_title),
+            description = stringResource(R.string.privacy_location_access_description),
             onClick = {
                 context.startActivity(
                     Intent(
@@ -75,8 +77,8 @@ fun PrivacyScreen(privacyViewModel: PrivacyViewModel = hiltViewModel()) {
             })
         SettingsLineSeparator()
         SettingsOption(
-            title = "Notification Access",
-            description = "Used to send device notifications",
+            title = stringResource(R.string.privacy_notification_access_title),
+            description = stringResource(R.string.privacy_notification_access_description),
             onClick = {
                 val intent = Intent(android.provider.Settings.ACTION_APP_NOTIFICATION_SETTINGS)
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -97,14 +99,14 @@ fun PrivacyScreen(privacyViewModel: PrivacyViewModel = hiltViewModel()) {
         )
         SettingsLineSeparator()
         Text(
-            text = "Analytics",
+            text = stringResource(R.string.privacy_analytics_heading),
             color = Color.Black,
             style = EateryBlueTypography.h4,
             modifier = Modifier.padding(top = 28.dp)
         )
         SwitchOption(
-            title = "Share with Cornell AppDev",
-            description = "Help us improve products and services",
+            title = stringResource(R.string.privacy_share_with_cornell_appdev_title),
+            description = stringResource(R.string.privacy_share_with_cornell_appdev_description),
             initialValue = !privacyViewModel.analyticsDisabled,
             onCheckedChange = { switched ->
                 privacyViewModel.setAnalyticsDisabled(switched)
@@ -114,7 +116,7 @@ fun PrivacyScreen(privacyViewModel: PrivacyViewModel = hiltViewModel()) {
         SettingsLineSeparator()
 
         SettingsOption(
-            title = "Privacy Policy",
+            title = stringResource(R.string.privacy_policy_title),
             onClick = { uriCurrent.openUri("https://www.cornellappdev.com/privacy") },
             trailingIcon = {
                 Icon(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SearchScreen.kt
@@ -383,7 +383,7 @@ fun FavoriteItem(
                             .clip(RoundedCornerShape(10.dp)),
                         contentScale = ContentScale.Crop,
                         painter = painterResource(id = R.drawable.blank_eatery_square),
-                        contentDescription = stringResource(R.string.eatery_image),
+                        contentDescription = stringResource(R.string.a11y_eatery_image),
                     )
                 })
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SearchScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -150,7 +151,7 @@ fun SearchScreen(
                     onSearchTextChange = {
                         searchViewModel.queryEateries(it)
                     },
-                    placeholderText = "Search for grub...",
+                    placeholderText = stringResource(R.string.search_placeholder_grub),
                     modifier = Modifier.padding(
                         top = 64.dp,
                         bottom = 6.dp,
@@ -221,7 +222,8 @@ fun SearchScreen(
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
                                     Text(
-                                        text = "Favorites", style = EateryBlueTypography.h4
+                                        text = stringResource(R.string.search_favorites),
+                                        style = EateryBlueTypography.h4
                                     )
                                     IconButton(
                                         onClick = {
@@ -236,7 +238,7 @@ fun SearchScreen(
                                     ) {
                                         Icon(
                                             Icons.AutoMirrored.Filled.ArrowForward,
-                                            contentDescription = "Favorites",
+                                            contentDescription = stringResource(R.string.search_favorites),
                                             tint = Color.Black
                                         )
                                     }
@@ -260,7 +262,7 @@ fun SearchScreen(
                 item {
                     Text(
                         modifier = Modifier.padding(start = 16.dp, top = 12.dp),
-                        text = "Recent Searches",
+                        text = stringResource(R.string.search_recent_searches),
                         style = EateryBlueTypography.h4
                     )
                 }
@@ -381,7 +383,7 @@ fun FavoriteItem(
                             .clip(RoundedCornerShape(10.dp)),
                         contentScale = ContentScale.Crop,
                         painter = painterResource(id = R.drawable.blank_eatery_square),
-                        contentDescription = "Eatery Image",
+                        contentDescription = stringResource(R.string.eatery_image),
                     )
                 })
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.cornellappdev.android.eatery.R
@@ -86,7 +87,7 @@ fun SettingsScreen(
             .padding(top = 48.dp, start = 16.dp, end = 16.dp)
     ) {
                 Text(
-                    text = "Settings",
+                    text = stringResource(R.string.settings_title),
                     color = EateryBlue,
                     style = EateryBlueTypography.h2,
                     modifier = Modifier.padding(top = 7.dp, bottom = 7.dp)
@@ -107,8 +108,8 @@ fun SettingsScreen(
                             tint = EateryBlue,
                         )
                     },
-                    title = "About Eatery",
-                    description = "Learn more about Cornell AppDev",
+                    title = stringResource(R.string.settings_about_title),
+                    description = stringResource(R.string.settings_about_description),
                     onClick = {
                         destinations[Routes.ABOUT]?.invoke()
                     }
@@ -122,14 +123,14 @@ fun SettingsScreen(
                             modifier = Modifier.size(24.dp)
                         )
                     },
-                    title = "App Icon",
-                    description = "Select the Eatery app icon for your phone",
+                    description = stringResource(R.string.settings_app_icon_description),
+                    title = stringResource(R.string.settings_app_icon_title),
                     onClick = {
                         showAppIconSheet = true
                     },
                     trailingIcon = {
                         Text(
-                            text = "Change",
+                            text = stringResource(R.string.settings_change),
                             style = EateryBlueTypography.button,
                             color = EateryBlue,
                         )
@@ -140,7 +141,7 @@ fun SettingsScreen(
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Outlined.StarOutline,
-                            contentDescription = "Favorites",
+                            contentDescription = stringResource(R.string.settings_favorites_title),
                             tint = GrayFive,
                             modifier = Modifier.size(24.dp)
                         )
@@ -152,8 +153,8 @@ fun SettingsScreen(
                             tint = EateryBlue,
                         )
                     },
-                    title = "Favorites",
-                    description = "Manage your favorite eateries and items",
+                    title = stringResource(R.string.settings_favorites_title),
+                    description = stringResource(R.string.settings_favorites_description),
                     onClick = {
                         destinations[Routes.FAVORITES]?.invoke()
                     }
@@ -168,8 +169,8 @@ fun SettingsScreen(
                             modifier = Modifier.size(24.dp)
                         )
                     },
-                    title = "Notifications",
-                    description = "Manage item and promotional notifications",
+                    title = stringResource(R.string.settings_notifications_title),
+                    description = stringResource(R.string.settings_notifications_description),
                     onClick = {
                         destinations[Routes.NOTIFICATIONS_SETTING]?.invoke()
                     },
@@ -186,7 +187,7 @@ fun SettingsScreen(
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Outlined.Lock,
-                            contentDescription = "Privacy",
+                            contentDescription = stringResource(R.string.settings_privacy_title),
                             tint = GrayFive,
                             modifier = Modifier.size(24.dp)
                         )
@@ -198,8 +199,8 @@ fun SettingsScreen(
                             tint = EateryBlue,
                         )
                     },
-                    title = "Privacy",
-                    description = "Manage permissions and analytics",
+                    title = stringResource(R.string.settings_privacy_title),
+                    description = stringResource(R.string.settings_privacy_description),
                     onClick = {
                         destinations[Routes.PRIVACY]?.invoke()
                     }
@@ -209,7 +210,7 @@ fun SettingsScreen(
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Outlined.Gavel,
-                            contentDescription = "Legal",
+                            contentDescription = stringResource(R.string.settings_legal_title),
                             tint = GrayFive,
                             modifier = Modifier.size(24.dp)
                         )
@@ -221,8 +222,8 @@ fun SettingsScreen(
                             tint = EateryBlue,
                         )
                     },
-                    title = "Legal",
-                    description = "Find terms, conditions, and privacy policy",
+                    title = stringResource(R.string.settings_legal_title),
+                    description = stringResource(R.string.settings_legal_description),
                     onClick = {
                         destinations[Routes.LEGAL]?.invoke()
                     }
@@ -232,7 +233,7 @@ fun SettingsScreen(
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.AutoMirrored.Outlined.HelpOutline,
-                            contentDescription = "Support",
+                            contentDescription = stringResource(R.string.settings_support_title),
                             tint = GrayFive,
                             modifier = Modifier.size(24.dp)
                         )
@@ -244,8 +245,8 @@ fun SettingsScreen(
                             tint = EateryBlue,
                         )
                     },
-                    title = "Support",
-                    description = "Report issues and contact Cornell Appdev",
+                    title = stringResource(R.string.settings_support_title),
+                    description = stringResource(R.string.settings_support_description),
                     onClick = {
                         destinations[Routes.SUPPORT]?.invoke()
                     }
@@ -278,7 +279,7 @@ fun SettingsScreen(
                         )
                         Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                         Text(
-                            text = "Log out",
+                            text = stringResource(R.string.settings_logout),
                             style = EateryBlueTypography.button
                         )
                     }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SupportScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SupportScreen.kt
@@ -67,6 +67,9 @@ import kotlinx.coroutines.launch
 fun SupportScreen(supportViewModel: SupportViewModel = hiltViewModel()) {
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
+    val reportingIssueSubject = stringResource(R.string.support_reporting_issue_subject)
+    val orderFoodSubject = stringResource(R.string.support_order_food_subject)
+    val emailChooserTitle = stringResource(R.string.support_email_chooser_title)
     val reportState by supportViewModel.reportState.collectAsStateWithLifecycle()
     val modalBottomSheetState = rememberModalBottomSheetState(
         skipPartiallyExpanded = true,
@@ -113,26 +116,26 @@ fun SupportScreen(supportViewModel: SupportViewModel = hiltViewModel()) {
                     .then(Modifier.statusBarsPadding())
             ) {
                 Text(
-                    text = "Support",
+                    text = stringResource(R.string.support_title),
                     color = EateryBlue,
                     style = EateryBlueTypography.h2,
                     modifier = Modifier.padding(top = 7.dp)
                 )
                 Text(
-                    text = "Report issues and contact Cornell AppDev",
+                    text = stringResource(R.string.support_description),
                     style = TextStyle(fontWeight = FontWeight.Medium, fontSize = 18.sp),
                     color = GraySix,
                     modifier = Modifier.padding(top = 7.dp, bottom = 24.dp)
                 )
 
                 Text(
-                    text = "Make Eatery Better",
+                    text = stringResource(R.string.support_make_eatery_better),
                     color = Color.Black,
                     style = EateryBlueTypography.h4,
                     modifier = Modifier.padding(bottom = 12.dp)
                 )
                 Text(
-                    text = "Help us improve Eatery by letting us know what’s wrong.",
+                    text = stringResource(R.string.support_make_eatery_better_description),
                     color = GrayFive,
                     style = EateryBlueTypography.subtitle2,
                     modifier = Modifier.padding(bottom = 12.dp)
@@ -153,7 +156,7 @@ fun SupportScreen(supportViewModel: SupportViewModel = hiltViewModel()) {
                 ) {
                     Icon(imageVector = Icons.Default.Report, Icons.Default.Report.name)
                     Text(
-                        text = "Report an Issue",
+                        text = stringResource(R.string.report_an_issue),
                         style = EateryBlueTypography.h5,
                         modifier = Modifier.padding(start = 8.dp)
                     )
@@ -162,11 +165,11 @@ fun SupportScreen(supportViewModel: SupportViewModel = hiltViewModel()) {
                 TextButton(modifier = Modifier.align(Alignment.CenterHorizontally), onClick = {
                     val email = Intent(Intent.ACTION_SENDTO)
                     email.data =
-                        "mailto:team@cornellappdev.com?subject=${Uri.encode("Eatery - Reporting an Issue")}".toUri()
-                    context.startActivity(Intent.createChooser(email, "Choose an Email client :"))
+                        "mailto:team@cornellappdev.com?subject=${Uri.encode(reportingIssueSubject)}".toUri()
+                    context.startActivity(Intent.createChooser(email, emailChooserTitle))
                 }) {
                     Text(
-                        text = "Shoot us an email",
+                        text = stringResource(R.string.support_email_us),
                         style = EateryBlueTypography.button,
                         color = EateryBlue
                     )
@@ -179,13 +182,13 @@ fun SupportScreen(supportViewModel: SupportViewModel = hiltViewModel()) {
                 }
 
                 Text(
-                    text = "Frequently Asked Questions",
+                    text = stringResource(R.string.support_faqs_heading),
                     style = EateryBlueTypography.h4,
                     color = Color.Black,
                     modifier = Modifier.padding(top = 20.dp)
                 )
                 FAQCreation(
-                    title = "Why do I see wrong or empty menus?",
+                    title = stringResource(R.string.support_faq_wrong_menus_title),
                     dropdownText = stringResource(id = R.string.wrong_empty_menus),
                     action = {
                         ReportButton()
@@ -196,7 +199,7 @@ fun SupportScreen(supportViewModel: SupportViewModel = hiltViewModel()) {
                 }
 
                 FAQCreation(
-                    title = "Why is an eatery closed when it says it should be open?",
+                    title = stringResource(R.string.support_faq_closed_hours_title),
                     dropdownText = stringResource(id = R.string.eatery_closed_when_open),
                     action = {
                         ReportButton()
@@ -207,7 +210,7 @@ fun SupportScreen(supportViewModel: SupportViewModel = hiltViewModel()) {
                 }
 
                 FAQCreation(
-                    title = "Why are the wait times longer?",
+                    title = stringResource(R.string.support_faq_wait_times_title),
                     dropdownText = stringResource(id = R.string.wait_time_longer),
                     action = {
                         ReportButton()
@@ -218,12 +221,12 @@ fun SupportScreen(supportViewModel: SupportViewModel = hiltViewModel()) {
                 }
 
                 FAQCreation(
-                    title = "Why can’t I order food on Eatery?",
+                    title = stringResource(R.string.support_faq_order_title),
                     dropdownText = stringResource(id = R.string.order_on_eatery),
                     action = {
                         Row {
                             Text(
-                                text = "send them an email.",
+                                text = stringResource(R.string.support_faq_order_email_prompt),
                                 style = EateryBlueTypography.subtitle2,
                                 color = EateryBlue,
                             )
@@ -232,9 +235,9 @@ fun SupportScreen(supportViewModel: SupportViewModel = hiltViewModel()) {
                 ) {
                     val email = Intent(Intent.ACTION_SENDTO)
                     email.data =
-                        "mailto:dining@cornell.edu?subject=${Uri.encode("Ordering Food on Eatery")}".toUri()
+                        "mailto:dining@cornell.edu?subject=${Uri.encode(orderFoodSubject)}".toUri()
 
-                    context.startActivity(Intent.createChooser(email, "Choose an Email client :"))
+                    context.startActivity(Intent.createChooser(email, emailChooserTitle))
                 }
             }
 }
@@ -256,7 +259,7 @@ private fun ReportButton() {
             Icon(imageVector = Icons.Default.Report, Icons.Default.Report.name)
             Spacer(Modifier.size(ButtonDefaults.IconSpacing))
             Text(
-                text = "Report an Issue",
+                text = stringResource(R.string.report_an_issue),
                 style = EateryBlueTypography.button,
                 color = Color.Black,
             )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/UpcomingMenuScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/UpcomingMenuScreen.kt
@@ -18,8 +18,6 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -299,7 +297,7 @@ private fun UpcomingFilterRow(
                     },
                     selected = true,
                     text = mealFilter.displayName,
-                    icon = Icons.Default.ExpandMore
+                    hasExpandIcon = true
                 )
             }
         },

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/FavoritesViewModel.kt
@@ -193,22 +193,15 @@ class FavoritesViewModel @Inject constructor(
         else -> Int.MAX_VALUE
     }
 
-    fun toggleFavoriteMenuItem(menuItemName: String) = viewModelScope.launch {
-        val isRemoving = menuItemName in userRepository.favoriteItemsFlow.value
-        val result = if (isRemoving) {
-            userRepository.removeFavoriteItem(menuItemName)
-        } else {
-            userRepository.addFavoriteItem(menuItemName)
-        }
-
-        when (result) {
+    fun removeFavoriteMenuItem(menuItemName: String) = viewModelScope.launch {
+        when (val result = userRepository.removeFavoriteItem(menuItemName)) {
             is Result.Success -> {
                 _error.value = null
             }
 
             is Result.Error -> {
                 _error.value = NetworkUiError.Failed(
-                    if (isRemoving) NetworkAction.RemoveFavoriteItem else NetworkAction.AddFavoriteItem,
+                    NetworkAction.RemoveFavoriteItem,
                     result.error
                 )
             }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/state/NetworkErrorHandler.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/state/NetworkErrorHandler.kt
@@ -2,6 +2,7 @@ package com.cornellappdev.android.eatery.ui.viewmodels.state
 
 import android.content.Context
 import android.widget.Toast
+import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.data.models.NetworkError
 
 /**
@@ -17,7 +18,7 @@ object NetworkErrorHandler {
 
         when (error) {
             is NetworkUiError.Failed -> {
-                val message = buildErrorMessage(error.action, error.reason)
+                val message = buildErrorMessage(context, error.action, error.reason)
                 Toast.makeText(context, message, Toast.LENGTH_LONG).show()
             }
         }
@@ -26,19 +27,27 @@ object NetworkErrorHandler {
     /**
      * Builds a user-friendly error message based on the action and network error reason.
      */
-    private fun buildErrorMessage(action: NetworkAction, reason: NetworkError): String {
-        val actionDescription = when (action) {
-            NetworkAction.AddFavoriteEatery -> "add favorite eatery"
-            NetworkAction.RemoveFavoriteEatery -> "remove favorite eatery"
-            NetworkAction.AddFavoriteItem -> "add favorite item"
-            NetworkAction.RemoveFavoriteItem -> "remove favorite item"
-            NetworkAction.UpdateFavorites -> "sync favorites"
-            NetworkAction.SendReport -> "send report"
-            NetworkAction.LinkGetAccount -> "link account"
-            NetworkAction.GetFinancials -> "load account information"
+    private fun buildErrorMessage(
+        context: Context,
+        action: NetworkAction,
+        reason: NetworkError
+    ): String {
+        val actionDescriptionRes = when (action) {
+            NetworkAction.AddFavoriteEatery -> R.string.network_action_add_favorite_eatery
+            NetworkAction.RemoveFavoriteEatery -> R.string.network_action_remove_favorite_eatery
+            NetworkAction.AddFavoriteItem -> R.string.network_action_add_favorite_item
+            NetworkAction.RemoveFavoriteItem -> R.string.network_action_remove_favorite_item
+            NetworkAction.UpdateFavorites -> R.string.network_action_update_favorites
+            NetworkAction.SendReport -> R.string.network_action_send_report
+            NetworkAction.LinkGetAccount -> R.string.network_action_link_get_account
+            NetworkAction.GetFinancials -> R.string.network_action_get_financials
         }
 
-        return "Failed to $actionDescription: $reason"
+        return context.getString(
+            R.string.network_error_message,
+            context.getString(actionDescriptionRes),
+            reason
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
 
     <string name="no_eatery_found">No eatery found…</string>
     <string name="reset_filters">Reset filters</string>
+    <string name="expand_filters">Expand filters</string>
     <string name="change_date">Change date</string>
     <string name="back">Back</string>
     <string name="search">Search</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,16 @@
     <string name="meal_time_lunch">10:30 AM-4:00 PM</string>
     <string name="meal_time_dinner">5:00 PM-8:30 PM</string>
     <string name="meal_time_late_dinner">8:30 PM-10:30 PM</string>
+    <string name="a11y_meal_selected_breakfast">Breakfast selected</string>
+    <string name="a11y_meal_select_breakfast">Select breakfast</string>
+    <string name="a11y_meal_selected_lunch">Lunch selected</string>
+    <string name="a11y_meal_select_lunch">Select lunch</string>
+    <string name="a11y_meal_selected_dinner">Dinner selected</string>
+    <string name="a11y_meal_select_dinner">Select dinner</string>
+    <string name="a11y_meal_selected_late_dinner">Late dinner selected</string>
+    <string name="a11y_meal_select_late_dinner">Select late dinner</string>
+    <string name="a11y_account_selected">%1$s selected</string>
+    <string name="a11y_account_select">Select %1$s</string>
     <string name="show_menu">Show menu</string>
     <string name="reset">Reset</string>
     <string name="close">Close</string>
@@ -103,6 +113,16 @@
     <string name="back">Back</string>
     <string name="search">Search</string>
     <string name="favorites_title">Favorites</string>
+    <string name="account_title">Account</string>
+    <string name="account_meal_plan">Meal Plan</string>
+    <string name="account_type_meal_swipes">Meal Swipes</string>
+    <string name="account_type_big_red_bucks">Big Red Bucks</string>
+    <string name="account_type_city_bucks">City Bucks</string>
+    <string name="account_type_laundry">Laundry</string>
+    <string name="account_search_transactions_placeholder">Search for transactions…</string>
+    <string name="account_past_30_days">Past 30 Days</string>
+    <string name="account_show_transactions">Show transactions</string>
+    <string name="a11y_change_account_type">Change account type</string>
 
     <string name="permission_location_message">Location permissions are necessary to show you eateries that are the closest to you!</string>
     <string name="permission_location_message_with_settings">Location permissions are necessary to show you eateries that are the closest to you!\n\nPlease click the button below to go to the settings to enable location permissions.</string>
@@ -110,12 +130,12 @@
     <string name="request_permission">Request Permission</string>
     <string name="open_settings">Open Settings</string>
 
-    <string name="home_error_icon_desc">Error Icon</string>
+    <string name="a11y_home_error_icon_desc">Error Icon</string>
     <string name="home_error_title">Hmm, no chow here (yet).</string>
     <string name="home_error_description">We ran into an issue loading this page. Check your connection or try reloading the page.</string>
     <string name="home_error_try_again">Try Again</string>
-    <string name="list_view">List View</string>
-    <string name="grid_view">Grid View</string>
+    <string name="a11y_list_view">List View</string>
+    <string name="a11y_grid_view">Grid View</string>
     <string name="all_eateries_title">All Eateries</string>
 
     <string name="eatery_detail_error">Cannot load Eatery Details</string>
@@ -127,9 +147,9 @@
     <string name="hours_title">Hours</string>
     <string name="make_eatery_better">Make Eatery Better</string>
     <string name="make_eatery_better_description">Help us make this info more accurate by letting us know what’s wrong.</string>
-    <string name="eatery_image">Eatery Image</string>
-    <string name="phone_order_online">Phone - Order Online</string>
-    <string name="walk_get_directions">Walk - Get Directions</string>
+    <string name="a11y_eatery_image">Eatery Image</string>
+    <string name="a11y_phone_order_online">Phone - Order Online</string>
+    <string name="a11y_walk_get_directions">Walk - Get Directions</string>
     <string name="no_app_available_to_open_this_link">No app available to open this link.</string>
     <string name="no_maps_app_available_on_this_device">No maps app available on this device.</string>
     <string name="closed">Closed</string>
@@ -138,7 +158,7 @@
     <string name="unknown_location">Unknown location</string>
     <string name="menu_time_range">%1$s - %2$s</string>
     <string name="week_day_time_range">%1$s - %2$s</string>
-    <string name="expand_menu">Expand menu</string>
+    <string name="a11y_expand_menu">Expand menu</string>
     <string name="bullet_separator">•</string>
     <string name="unknown_item">Unknown</string>
     <string name="view_eatery_details">View Eatery Details</string>
@@ -148,7 +168,7 @@
     <string name="closing_soon">Closing soon</string>
     <string name="closing_in_minutes">Closing in %1$d min</string>
     <string name="min_walk">%1$s min walk</string>
-    <string name="search_icon">Search</string>
+    <string name="a11y_search_icon">Search</string>
     <string name="search_cancel">Cancel</string>
     <string name="search_placeholder_menu">Search the menu…</string>
     <string name="search_placeholder_grub">Search for grub…</string>
@@ -179,7 +199,7 @@
     <string name="favorite_button_add">Add to favorites</string>
     <string name="favorite_button_remove">Remove from favorites</string>
     <string name="today">Today</string>
-    <string name="notification_star_icon">Notification Star Icon</string>
+    <string name="a11y_notification_star_icon">Notification Star Icon</string>
     <string name="compare_menus_title">Compare Menus</string>
     <string name="compare_menus_no_menu">Sorry, there is no menu available now.</string>
     <string name="done">Done</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">Eatery</string>
+    <string name="favorites_load_error">Failed to obtain eatery data</string>
     <string name="wrong_empty_menus">We work with Cornell Dining to get the most accurate menus to students. Sometimes, eateries change menus on the fly or run out of a certain item and have to serve something different.\n\nIf you see inaccurate menus, help us improve Eatery by letting us know what’s wrong.</string>
     <string name="eatery_closed_when_open">We work with Cornell Dining to get the most accurate hours to students. However, sometimes hours change suddenly because of special events or weather.\n\nIf you see incorrect hours, help us improve Eatery by letting us know the correct hours.</string>
     <string name="wait_time_longer">We work with Cornell Dining to get the most accurate wait times to students. Sometimes, wait times can grow when classes or events end around meal times.\n\nIf you see inaccurate wait times, help us improve Eatery by letting us know how long you waited.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="a11y_meal_select_late_dinner">Select late dinner</string>
     <string name="a11y_account_selected">%1$s selected</string>
     <string name="a11y_account_select">Select %1$s</string>
+    <string name="a11y_settings">Settings</string>
     <string name="show_menu">Show menu</string>
     <string name="reset">Reset</string>
     <string name="close">Close</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,8 +148,6 @@
     <string name="make_eatery_better">Make Eatery Better</string>
     <string name="make_eatery_better_description">Help us make this info more accurate by letting us know what’s wrong.</string>
     <string name="a11y_eatery_image">Eatery Image</string>
-    <string name="a11y_phone_order_online">Phone - Order Online</string>
-    <string name="a11y_walk_get_directions">Walk - Get Directions</string>
     <string name="no_app_available_to_open_this_link">No app available to open this link.</string>
     <string name="no_maps_app_available_on_this_device">No maps app available on this device.</string>
     <string name="closed">Closed</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,209 @@
 <resources>
     <string name="app_name">Eatery</string>
+
     <string name="favorites_load_error">Failed to obtain eatery data</string>
     <string name="wrong_empty_menus">We work with Cornell Dining to get the most accurate menus to students. Sometimes, eateries change menus on the fly or run out of a certain item and have to serve something different.\n\nIf you see inaccurate menus, help us improve Eatery by letting us know what’s wrong.</string>
     <string name="eatery_closed_when_open">We work with Cornell Dining to get the most accurate hours to students. However, sometimes hours change suddenly because of special events or weather.\n\nIf you see incorrect hours, help us improve Eatery by letting us know the correct hours.</string>
     <string name="wait_time_longer">We work with Cornell Dining to get the most accurate wait times to students. Sometimes, wait times can grow when classes or events end around meal times.\n\nIf you see inaccurate wait times, help us improve Eatery by letting us know how long you waited.</string>
     <string name="order_on_eatery">We would love to develop an ordering app for Cornell. Unfortunately, Cornell works with GET™ App instead of us.\n\nIf you’d like them to change their mind, you can"</string>
+
+    <string name="settings_title">Settings</string>
+    <string name="settings_about_title">About Eatery</string>
+    <string name="settings_about_description">Learn more about Cornell AppDev</string>
+    <string name="settings_app_icon_title">App Icon</string>
+    <string name="settings_app_icon_description">Select the Eatery app icon for your phone</string>
+    <string name="settings_change">Change</string>
+    <string name="settings_favorites_title">Favorites</string>
+    <string name="settings_favorites_description">Manage your favorite eateries and items</string>
+    <string name="settings_notifications_title">Notifications</string>
+    <string name="settings_notifications_description">Manage item and promotional notifications</string>
+    <string name="settings_privacy_title">Privacy</string>
+    <string name="settings_privacy_description">Manage permissions and analytics</string>
+    <string name="settings_legal_title">Legal</string>
+    <string name="settings_legal_description">Find terms, conditions, and privacy policy</string>
+    <string name="settings_support_title">Support</string>
+    <string name="settings_support_description">Report issues and contact Cornell AppDev</string>
+    <string name="settings_logout">Log out</string>
+
+    <string name="about_title">About Eatery</string>
+    <string name="about_description">Learn more about Cornell AppDev</string>
+    <string name="about_designed_and_developed_by">DESIGNED AND DEVELOPED BY</string>
+    <string name="about_cornell">Cornell</string>
+    <string name="about_appdev">AppDev</string>
+    <string name="about_website_button">Visit our website</string>
+
+    <string name="legal_title">Legal</string>
+    <string name="legal_description">Find terms, conditions, and privacy policy</string>
+    <string name="legal_terms_and_conditions">Terms and Conditions</string>
+    <string name="legal_privacy_policy">Privacy Policy</string>
+
+    <string name="notifications_title">Notifications</string>
+    <string name="notifications_description">Manage item and promotional notifications</string>
+    <string name="notifications_all_title">All Notifications</string>
+    <string name="notifications_favorite_item_title">Favorite item being served</string>
+    <string name="notifications_favorite_item_description">Get notified when favorite items are served</string>
+    <string name="notifications_favorite_eatery_open_title">Favorite eatery opening</string>
+    <string name="notifications_favorite_eatery_open_description">Get notified when your favorite eatery opens</string>
+    <string name="notifications_favorite_eatery_close_title">Favorite eatery closing</string>
+    <string name="notifications_favorite_eatery_close_description">Get notified when your favorite eatery closes</string>
+
+    <string name="privacy_title">Privacy</string>
+    <string name="privacy_description">Manage permissions and analytics</string>
+    <string name="privacy_permissions_heading">Permissions</string>
+    <string name="privacy_location_access_title">Location Access</string>
+    <string name="privacy_location_access_description">Used to find eateries near you</string>
+    <string name="privacy_notification_access_title">Notification Access</string>
+    <string name="privacy_notification_access_description">Used to send device notifications</string>
+    <string name="privacy_analytics_heading">Analytics</string>
+    <string name="privacy_share_with_cornell_appdev_title">Share with Cornell AppDev</string>
+    <string name="privacy_share_with_cornell_appdev_description">Help us improve products and services</string>
+    <string name="privacy_policy_title">Privacy Policy</string>
+
+    <string name="support_title">Support</string>
+    <string name="support_description">Report issues and contact Cornell AppDev</string>
+    <string name="support_make_eatery_better">Make Eatery Better</string>
+    <string name="support_make_eatery_better_description">Help us improve Eatery by letting us know what’s wrong.</string>
+    <string name="report_an_issue">Report an Issue</string>
+    <string name="support_email_us">Shoot us an email</string>
+    <string name="support_faqs_heading">Frequently Asked Questions</string>
+    <string name="support_faq_wrong_menus_title">Why do I see wrong or empty menus?</string>
+    <string name="support_faq_closed_hours_title">Why is an eatery closed when it says it should be open?</string>
+    <string name="support_faq_wait_times_title">Why are the wait times longer?</string>
+    <string name="support_faq_order_title">Why can’t I order food on Eatery?</string>
+    <string name="support_faq_order_email_prompt">send them an email.</string>
+    <string name="support_email_chooser_title">Choose an Email client :</string>
+    <string name="support_order_food_subject">Ordering Food on Eatery</string>
+    <string name="support_reporting_issue_subject">Eatery - Reporting an Issue</string>
+
+    <string name="upcoming_menus_title">Upcoming Menus</string>
+    <string name="menus_title">Menus</string>
+    <string name="meal_breakfast">Breakfast</string>
+    <string name="meal_lunch">Lunch</string>
+    <string name="meal_dinner">Dinner</string>
+    <string name="meal_late_dinner">Late Dinner</string>
+    <string name="meal_time_breakfast">7:30 AM-10:30 AM</string>
+    <string name="meal_time_lunch">10:30 AM-4:00 PM</string>
+    <string name="meal_time_dinner">5:00 PM-8:30 PM</string>
+    <string name="meal_time_late_dinner">8:30 PM-10:30 PM</string>
+    <string name="show_menu">Show menu</string>
+    <string name="reset">Reset</string>
+    <string name="close">Close</string>
+    <string name="close_upcoming">Close Upcoming</string>
+
+    <string name="app_store_rating_positive_message">Awesome! We’d love to hear more in a review</string>
+    <string name="app_store_rating_positive_button">Open PlayStore</string>
+    <string name="app_store_rating_negative_message">Sorry to hear that.</string>
+    <string name="app_store_rating_negative_button">Visit support</string>
+    <string name="app_store_rating_question">How is your experience so far?</string>
+
+    <string name="no_eatery_found">No eatery found…</string>
+    <string name="reset_filters">Reset filters</string>
+    <string name="change_date">Change date</string>
+    <string name="back">Back</string>
+    <string name="search">Search</string>
+    <string name="favorites_title">Favorites</string>
+
+    <string name="permission_location_message">Location permissions are necessary to show you eateries that are the closest to you!</string>
+    <string name="permission_location_message_with_settings">Location permissions are necessary to show you eateries that are the closest to you!\n\nPlease click the button below to go to the settings to enable location permissions.</string>
+    <string name="permission_location_settings_message">Please click the button below to go to the settings to enable location permissions.</string>
+    <string name="request_permission">Request Permission</string>
+    <string name="open_settings">Open Settings</string>
+
+    <string name="home_error_icon_desc">Error Icon</string>
+    <string name="home_error_title">Hmm, no chow here (yet).</string>
+    <string name="home_error_description">We ran into an issue loading this page. Check your connection or try reloading the page.</string>
+    <string name="home_error_try_again">Try Again</string>
+    <string name="list_view">List View</string>
+    <string name="grid_view">Grid View</string>
+    <string name="all_eateries_title">All Eateries</string>
+
+    <string name="eatery_detail_error">Cannot load Eatery Details</string>
+    <string name="loading">Loading…</string>
+    <string name="eatery_detail_location_with_summary">%1$s · %2$s</string>
+    <string name="eatery_detail_location_only">%1$s</string>
+    <string name="order_online">Order online</string>
+    <string name="get_directions">Get directions</string>
+    <string name="hours_title">Hours</string>
+    <string name="make_eatery_better">Make Eatery Better</string>
+    <string name="make_eatery_better_description">Help us make this info more accurate by letting us know what’s wrong.</string>
+    <string name="eatery_image">Eatery Image</string>
+    <string name="phone_order_online">Phone - Order Online</string>
+    <string name="walk_get_directions">Walk - Get Directions</string>
+    <string name="no_app_available_to_open_this_link">No app available to open this link.</string>
+    <string name="no_maps_app_available_on_this_device">No maps app available on this device.</string>
+    <string name="closed">Closed</string>
+    <string name="closing_at">Closing at %1$s</string>
+    <string name="open_until">Open until %1$s</string>
+    <string name="unknown_location">Unknown location</string>
+    <string name="menu_time_range">%1$s - %2$s</string>
+    <string name="week_day_time_range">%1$s - %2$s</string>
+    <string name="expand_menu">Expand menu</string>
+    <string name="bullet_separator">•</string>
+    <string name="unknown_item">Unknown</string>
+    <string name="view_eatery_details">View Eatery Details</string>
+    <string name="recommended_for_you">Recommended for You:</string>
+    <string name="meal_swipes_allowed">Meal swipes allowed</string>
+    <string name="cash_or_credit_only">Cash or credit only</string>
+    <string name="closing_soon">Closing soon</string>
+    <string name="closing_in_minutes">Closing in %1$d min</string>
+    <string name="min_walk">%1$s min walk</string>
+    <string name="search_icon">Search</string>
+    <string name="search_cancel">Cancel</string>
+    <string name="search_placeholder_menu">Search the menu…</string>
+    <string name="search_placeholder_grub">Search for grub…</string>
+    <string name="search_favorites">Favorites</string>
+    <string name="search_recent_searches">Recent Searches</string>
+
+    <string name="notifications_home_title">Notifications</string>
+    <string name="notifications_home_favorite_items">Favorite Items</string>
+
+    <string name="nearest_title">Nearest to You</string>
+    <string name="nearest_empty_message">You currently have no favorite eateries!</string>
+
+    <string name="onboarding_eatery_title">Eatery</string>
+    <string name="onboarding_get_started">Get Started</string>
+    <string name="onboarding_cornell">Cornell</string>
+    <string name="onboarding_appdev">AppDev</string>
+
+    <string name="payment_methods_title">Payment Methods</string>
+    <string name="payment_methods_close">Close</string>
+    <string name="payment_methods_show_results">Show results</string>
+    <string name="payment_methods_reset">Reset</string>
+    <string name="payment_methods_meal_swipes">Meal Swipes</string>
+    <string name="payment_methods_brbs">BRBs</string>
+    <string name="payment_methods_cash_or_credit">Cash or credit</string>
+    <string name="payment_methods_pay_with">Pay with</string>
+    <string name="payment_methods_all">all payment methods</string>
+    <string name="payment_methods_or">or</string>
+    <string name="favorite_button_add">Add to favorites</string>
+    <string name="favorite_button_remove">Remove from favorites</string>
+    <string name="today">Today</string>
+    <string name="notification_star_icon">Notification Star Icon</string>
+    <string name="compare_menus_title">Compare Menus</string>
+    <string name="compare_menus_no_menu">Sorry, there is no menu available now.</string>
+    <string name="done">Done</string>
+
+    <string name="report_title">Report an Issue</string>
+    <string name="report_type_heading">Type of issue</string>
+    <string name="report_choose_option">Choose an option…</string>
+    <string name="report_description_heading">Description</string>
+    <string name="report_description_hint">Tell us what’s wrong…</string>
+    <string name="report_error_unable_to_send">Unable to send report. Please try again.</string>
+    <string name="report_submit">Submit</string>
+    <string name="report_issue_item">Inaccurate or missing item</string>
+    <string name="report_issue_price">Different price than listed</string>
+    <string name="report_issue_hours">Incorrect hours</string>
+    <string name="report_issue_wait_times">Inaccurate wait times</string>
+    <string name="report_issue_description">Inaccurate description</string>
+    <string name="report_issue_other">Other</string>
+
+    <string name="network_action_add_favorite_eatery">add favorite eatery</string>
+    <string name="network_action_remove_favorite_eatery">remove favorite eatery</string>
+    <string name="network_action_add_favorite_item">add favorite item</string>
+    <string name="network_action_remove_favorite_item">remove favorite item</string>
+    <string name="network_action_update_favorites">sync favorites</string>
+    <string name="network_action_send_report">send report</string>
+    <string name="network_action_link_get_account">link account</string>
+    <string name="network_action_get_financials">load account information</string>
+    <string name="network_error_message">Failed to %1$s: %2$s</string>
 </resources>


### PR DESCRIPTION
## Overview
- Centers the loading screen for favorites screen. 
- Add previews

## Related PRs or Issues
- Resolves #201 

## Screenshots

<img width="280" alt="image" src="https://github.com/user-attachments/assets/41a8f6d2-b74c-4e39-97e7-ec4976e96945" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Split Favorites UI into a smaller content component and expose filter/remove actions as parameters.

* **Style**
  * Centered and expanded loading layout; adjusted spacing/padding and error presentation.

* **Chores**
  * Added many localized strings (including a favorites load error) across settings, onboarding, search, menus, payments, and more; simplified favorite-item removal logic.

* **Accessibility / Localization**
  * Replaced hardcoded labels with localized resources and improved content descriptions.

* **Testing / Preview**
  * Added previews for Favorites: loading, loaded, and error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->