### PR TITLE
Enable edge-to-edge and fix insets

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
 
         <activity
             android:name=".MainActivity"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true"
             android:theme="@style/Theme.EateryBlue">
             <intent-filter>

--- a/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.kt
@@ -3,10 +3,10 @@ package com.cornellappdev.android.eatery
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.view.WindowCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -51,7 +51,7 @@ class MainActivity : ComponentActivity() {
 
         val hasOnboarded = runBlocking { userRepository.hasOnboarded() }
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+        enableEdgeToEdge()
 
         setContent {
             LockScreenOrientation()

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/onboarding/OnboardingCarousel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/onboarding/OnboardingCarousel.kt
@@ -98,7 +98,7 @@ fun OnboardingCarousel(
             Box {
                 HorizontalPager(
                     modifier = Modifier
-                        .padding(top = 16.dp, start = 0.dp, end = 0.dp)
+                        .padding(top = 16.dp)
                         .zIndex(1f),
                     state = phonePagerState,
                     contentPadding = PaddingValues(horizontal = 55.dp)

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/SwitchOption.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/SwitchOption.kt
@@ -26,7 +26,7 @@ fun SwitchOption(
     initialValue: Boolean = true
 ) {
     var switched by remember { mutableStateOf(initialValue) }
-    Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp)) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
         SettingsOption(
             title = title, description = description, onClick = { },
             trailingIcon = {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/AboutScreen.kt
@@ -62,7 +62,7 @@ fun AboutScreen() {
     Column(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
-                .padding(start = 16.dp, end = 16.dp)
+                .padding(horizontal = 16.dp)
                 .then(Modifier.statusBarsPadding())
                 .fillMaxWidth()
         ) {
@@ -132,7 +132,7 @@ fun AboutScreen() {
         Button(
             shape = RoundedCornerShape(24.dp),
             modifier = Modifier
-                .padding(start = 16.dp, end = 16.dp)
+                .padding(horizontal = 16.dp)
                 .then(Modifier.navigationBarsPadding())
                 .height(48.dp)
                 .fillMaxWidth(),
@@ -321,7 +321,7 @@ fun CreditsRow(position: TeamPosition) {
                     tint = GrayOne,
                     modifier = Modifier
                         .height(7.dp)
-                        .padding(start = 12.33.dp, end = 12.33.dp)
+                        .padding(horizontal = 12.33.dp)
                         .width(7.33.dp)
                 )
             })

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/AboutScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -61,7 +62,8 @@ fun AboutScreen() {
     Column(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
-                .padding(top = 36.dp, start = 16.dp, end = 16.dp)
+                .padding(start = 16.dp, end = 16.dp)
+                .then(Modifier.statusBarsPadding())
                 .fillMaxWidth()
         ) {
             Text(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -229,7 +230,8 @@ fun EateryDetailScreenContent(
                 openBottomSheet(BottomSheetContent.COMPARE_MENUS)
             }
         },
-        floatingActionButtonPosition = FabPosition.End
+        floatingActionButtonPosition = FabPosition.End,
+        contentWindowInsets = WindowInsets(0, 0, 0, 0)
     ) { paddingValues ->
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
@@ -106,7 +106,7 @@ private fun FavoritesScreenContent(
 
     Column(
         modifier = Modifier
-            .padding(start = 10.dp, end = 10.dp)
+            .padding(horizontal = 10.dp)
             .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {
@@ -136,7 +136,7 @@ private fun FavoritesScreenContent(
             text = stringResource(R.string.favorites_title),
             color = EateryBlue,
             style = EateryBlueTypography.h2,
-            modifier = Modifier.padding(start = 6.dp, end = 6.dp)
+            modifier = Modifier.padding(horizontal = 6.dp)
         )
 
         Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -105,7 +106,8 @@ private fun FavoritesScreenContent(
 
     Column(
         modifier = Modifier
-            .padding(top = 36.dp, start = 10.dp, end = 10.dp)
+            .padding(start = 10.dp, end = 10.dp)
+            .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {
         Row(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/HomeScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -206,6 +207,7 @@ fun HomeScreen(
             }
         },
         floatingActionButtonPosition = FabPosition.End,
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         content = { paddingValues ->
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/LegalScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/LegalScreen.kt
@@ -3,6 +3,7 @@ package com.cornellappdev.android.eatery.ui.screens
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowOutward
 import androidx.compose.material3.Icon
@@ -27,7 +28,8 @@ fun LegalScreen() {
     val uriCurrent = LocalUriHandler.current
     Column(
         modifier = Modifier
-            .padding(top = 36.dp, start = 16.dp, end = 16.dp)
+            .padding(start = 16.dp, end = 16.dp)
+            .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {
         Text(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/LegalScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/LegalScreen.kt
@@ -28,7 +28,7 @@ fun LegalScreen() {
     val uriCurrent = LocalUriHandler.current
     Column(
         modifier = Modifier
-            .padding(start = 16.dp, end = 16.dp)
+            .padding(horizontal = 16.dp)
             .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NearestScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NearestScreen.kt
@@ -52,7 +52,7 @@ fun NearestScreen(
 
     Column(
         modifier = Modifier
-            .padding(start = 16.dp, end = 16.dp)
+            .padding(horizontal = 16.dp)
             .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NearestScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NearestScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -51,7 +52,8 @@ fun NearestScreen(
 
     Column(
         modifier = Modifier
-            .padding(top = 36.dp, start = 16.dp, end = 16.dp)
+            .padding(start = 16.dp, end = 16.dp)
+            .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {
         Text(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NotificationsHomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NotificationsHomeScreen.kt
@@ -21,7 +21,7 @@ fun NotificationsHomeScreen(
 ) {
     Column(
         modifier = Modifier
-            .padding(start = 16.dp, end = 16.dp)
+            .padding(horizontal = 16.dp)
             .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NotificationsHomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NotificationsHomeScreen.kt
@@ -3,6 +3,7 @@ package com.cornellappdev.android.eatery.ui.screens
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,7 +21,8 @@ fun NotificationsHomeScreen(
 ) {
     Column(
         modifier = Modifier
-            .padding(top = 40.dp, start = 16.dp, end = 16.dp)
+            .padding(start = 16.dp, end = 16.dp)
+            .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {
         Text(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NotificationsSettingsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NotificationsSettingsScreen.kt
@@ -25,7 +25,7 @@ fun NotificationsSettingsScreen() {
 
     Column(
         modifier = Modifier
-            .padding(start = 16.dp, end = 16.dp)
+            .padding(horizontal = 16.dp)
             .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NotificationsSettingsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/NotificationsSettingsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -24,7 +25,8 @@ fun NotificationsSettingsScreen() {
 
     Column(
         modifier = Modifier
-            .padding(top = 36.dp, start = 16.dp, end = 16.dp)
+            .padding(start = 16.dp, end = 16.dp)
+            .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {
         Text(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/PrivacyScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/PrivacyScreen.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowOutward
 import androidx.compose.material3.Icon
@@ -37,7 +38,8 @@ fun PrivacyScreen(privacyViewModel: PrivacyViewModel = hiltViewModel()) {
 
     Column(
         modifier = Modifier
-            .padding(top = 36.dp, start = 16.dp, end = 16.dp)
+            .padding(start = 16.dp, end = 16.dp)
+            .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {
         Text(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/PrivacyScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/PrivacyScreen.kt
@@ -38,7 +38,7 @@ fun PrivacyScreen(privacyViewModel: PrivacyViewModel = hiltViewModel()) {
 
     Column(
         modifier = Modifier
-            .padding(start = 16.dp, end = 16.dp)
+            .padding(horizontal = 16.dp)
             .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SearchScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -145,7 +146,11 @@ fun SearchScreen(
 
     LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
         stickyHeader {
-            Column(modifier = Modifier.background(Color.White)) {
+            Column(
+                modifier = Modifier
+                    .background(Color.White)
+                    .then(Modifier.statusBarsPadding())
+            ) {
                 SearchBar(
                     searchText = query,
                     onSearchTextChange = {
@@ -153,7 +158,7 @@ fun SearchScreen(
                     },
                     placeholderText = stringResource(R.string.search_placeholder_grub),
                     modifier = Modifier.padding(
-                        top = 64.dp,
+                        top = 12.dp,
                         bottom = 6.dp,
                         start = 16.dp,
                         end = 16.dp

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SettingsScreen.kt
@@ -85,7 +85,7 @@ fun SettingsScreen(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 16.dp, end = 16.dp)
+            .padding(horizontal = 16.dp)
             .then(Modifier.statusBarsPadding())
     ) {
                 Text(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SettingsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
@@ -84,7 +85,8 @@ fun SettingsScreen(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 48.dp, start = 16.dp, end = 16.dp)
+            .padding(start = 16.dp, end = 16.dp)
+            .then(Modifier.statusBarsPadding())
     ) {
                 Text(
                     text = stringResource(R.string.settings_title),

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SupportScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SupportScreen.kt
@@ -111,7 +111,7 @@ fun SupportScreen(supportViewModel: SupportViewModel = hiltViewModel()) {
 
             Column(
                 modifier = Modifier
-                    .padding(start = 16.dp, end = 16.dp)
+                    .padding(horizontal = 16.dp)
                     .fillMaxSize()
                     .then(Modifier.statusBarsPadding())
             ) {


### PR DESCRIPTION
## Overview
- Enabled edge-to-edge
- Fixed incorrect top padding caused by default scaffold padding
- Use `statusBarPadding` instead of hardcoded top padding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status bar and system-inset handling across screens for consistent top spacing on different devices.
  * Enhanced soft keyboard behavior so content resizes reliably when the keyboard appears.
  * Enabled edge-to-edge display support for better screen utilization and a more consistent visual layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->