### PR TITLE
Simplify auth logic

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eatery/data/AuthInterceptor.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/AuthInterceptor.kt
@@ -46,7 +46,12 @@ class AuthInterceptor @Inject constructor(
                     val retryRequest = addTokenToRequest(request)
                     response = chain.proceed(retryRequest)
                 } catch (_: Exception) {
-                    return chain.proceed(request)
+                    return Response.Builder()
+                        .code(response.code)
+                        .message(response.message)
+                        .request(request)
+                        .protocol(response.protocol)
+                        .build()
                 }
             }
             return response

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/AuthInterceptor.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/AuthInterceptor.kt
@@ -9,10 +9,9 @@ import javax.inject.Inject
 import javax.inject.Provider
 
 /**
- * OkHttp interceptor that automatically adds Bearer token to authenticated requests.
- * Also handles token refresh on 401 responses.
+ * OkHttp interceptor that automatically adds a Bearer token to protected requests.
  *
- * Uses Provider<AuthTokenRepository> to avoid circular dependency
+ * Uses [Provider] to avoid a circular dependency with [AuthTokenRepository].
  */
 class AuthInterceptor @Inject constructor(
     private val authTokenRepositoryProvider: Provider<AuthTokenRepository>
@@ -26,6 +25,11 @@ class AuthInterceptor @Inject constructor(
         )
     }
 
+    /**
+     * Intercepts outgoing HTTP requests.
+     * Adds the Bearer token to protected requests.
+     * If the response is 401 or 403, refreshes tokens and retries once.
+     */
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
 
@@ -33,7 +37,7 @@ class AuthInterceptor @Inject constructor(
             val requestWithToken = addTokenToRequest(request)
             var response = chain.proceed(requestWithToken)
 
-            if (response.code == 401) {
+            if (response.code == 401 || response.code == 403) {
                 response.close()
                 try {
                     runBlocking {
@@ -45,10 +49,8 @@ class AuthInterceptor @Inject constructor(
                     return chain.proceed(request)
                 }
             }
-
             return response
         }
-
         return chain.proceed(request)
     }
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/AuthTokenRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/AuthTokenRepository.kt
@@ -19,67 +19,54 @@ class AuthTokenRepository @Inject constructor(
     private val _tokensConfiguredFlow: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     /**
-     * A [StateFlow] that emits whether tokens have been configured successfully.
+     * A [StateFlow] that emits whether the app has successfully stored a valid token pair.
      */
     val tokensConfiguredFlow: StateFlow<Boolean> = _tokensConfiguredFlow.asStateFlow()
 
-    suspend fun getDeviceId(): String = userPreferencesRepository.getOrCreateDeviceId()
-
     /**
-     * Fetches initial tokens from the API based on device ID.
+     * Fetches the initial token pair from the API using the device ID.
      * Called on app launch.
      */
-    suspend fun getTokens(): Result<Unit> = safeNetworkRequest {
-        val deviceId = getDeviceId()
-        val response = networkApi.verifyToken(DeviceId(deviceId))
-        val accessToken = response.accessToken
-        val refreshToken = response.refreshToken
-        if (accessToken != null) {
-            userPreferencesRepository.setAccessToken(accessToken)
-        } else {
-            throw Exception("Access token is null")
-        }
-        if (refreshToken != null) {
-            userPreferencesRepository.setRefreshToken(refreshToken)
-        } else {
-            throw Exception("Refresh token is null")
-        }
+    suspend fun getTokens(): Result<Unit> = resultOfNetworkCall {
+        val deviceId = userPreferencesRepository.getOrCreateDeviceId()
+        val tokenResponse = networkApi.verifyToken(DeviceId(deviceId))
+        storeTokens(
+            accessToken = tokenResponse.accessToken!!,
+            refreshToken = tokenResponse.refreshToken!!
+        )
     }
 
     fun markTokensAsConfigured() {
         _tokensConfiguredFlow.value = true
     }
 
-    suspend fun refreshTokens(): Result<Unit> = safeNetworkRequest {
-        val deviceId = getDeviceId()
+    /**
+     * Refreshes the current token pair using the stored refresh token.
+     */
+    suspend fun refreshTokens(): Result<Unit> = resultOfNetworkCall {
+        val deviceId = userPreferencesRepository.getOrCreateDeviceId()
         val refreshToken = userPreferencesRepository.refreshTokenFlow.firstOrNull()
             ?: throw IllegalStateException("Refresh token not available")
-        val tokens = networkApi.refreshToken(
+        val refreshedTokenResponse = networkApi.refreshToken(
             RefreshRequest(
                 deviceId = deviceId,
                 refreshToken = refreshToken
             )
         )
-        val accessToken = tokens.accessToken
-        val newRefreshToken = tokens.refreshToken
-        if (accessToken != null) {
-            userPreferencesRepository.setAccessToken(accessToken)
-        } else {
-            throw Exception("Access token is null")
-        }
-        if (newRefreshToken != null) {
-            userPreferencesRepository.setRefreshToken(newRefreshToken)
-        } else {
-            throw Exception("Refresh token is null")
-        }
+        storeTokens(
+            accessToken = refreshedTokenResponse.accessToken!!,
+            refreshToken = refreshedTokenResponse.refreshToken!!
+        )
     }
 
     suspend fun getAccessToken(): String =
-        prependBearer(
+        "Bearer ${
             userPreferencesRepository.accessTokenFlow.firstOrNull()
                 ?: throw IllegalStateException("Access token not available")
-        )
+        }"
 
-
-    private fun prependBearer(str: String) = "Bearer $str"
+    private suspend fun storeTokens(accessToken: String, refreshToken: String) {
+        userPreferencesRepository.setAccessToken(accessToken)
+        userPreferencesRepository.setRefreshToken(refreshToken)
+    }
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/AuthTokenRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/AuthTokenRepository.kt
@@ -30,9 +30,13 @@ class AuthTokenRepository @Inject constructor(
     suspend fun getTokens(): Result<Unit> = resultOfNetworkCall {
         val deviceId = userPreferencesRepository.getOrCreateDeviceId()
         val tokenResponse = networkApi.verifyToken(DeviceId(deviceId))
+        val accessToken = tokenResponse.accessToken
+            ?: throw IllegalStateException("verifyToken returned null access token")
+        val refreshToken = tokenResponse.refreshToken
+            ?: throw IllegalStateException("verifyToken returned null refresh token")
         storeTokens(
-            accessToken = tokenResponse.accessToken!!,
-            refreshToken = tokenResponse.refreshToken!!
+            accessToken = accessToken,
+            refreshToken = refreshToken
         )
     }
 
@@ -53,9 +57,13 @@ class AuthTokenRepository @Inject constructor(
                 refreshToken = refreshToken
             )
         )
+        val accessToken = refreshedTokenResponse.accessToken
+            ?: throw IllegalStateException("refreshToken returned null access token")
+        val refreshTokenFromResponse = refreshedTokenResponse.refreshToken
+            ?: throw IllegalStateException("refreshToken returned null refresh token")
         storeTokens(
-            accessToken = refreshedTokenResponse.accessToken!!,
-            refreshToken = refreshedTokenResponse.refreshToken!!
+            accessToken = accessToken,
+            refreshToken = refreshTokenFromResponse
         )
     }
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/GETAccountRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/GETAccountRepository.kt
@@ -12,14 +12,13 @@ import kotlin.random.Random
 @Singleton
 class GETAccountRepository @Inject constructor(
     private val networkApi: NetworkApi,
-    private val userPreferencesRepository: UserPreferencesRepository,
-    private val authTokenRepository: AuthTokenRepository
+    private val userPreferencesRepository: UserPreferencesRepository
 ) {
     suspend fun linkGETAccount(sessionId: String): Result<Unit> {
         userPreferencesRepository.setSessionId(sessionId)
         val pin = Random.nextInt(10000)
         userPreferencesRepository.setPin(pin)
-        return tryRequestWithResult {
+        return resultOfNetworkCall {
             networkApi.authorizeUser(
                 loginRequest = LoginRequest(pin.toString(), sessionId)
             )
@@ -30,15 +29,11 @@ class GETAccountRepository @Inject constructor(
         }
     }
 
-    suspend fun refreshLogin(pin: Int): Result<Unit> = tryRequestWithResult {
+    suspend fun refreshLogin(pin: Int): Result<Unit> = resultOfNetworkCall {
         val newSessionId = networkApi.refreshAuthorizedUser(
             loginPIN = LoginPIN(pin.toString())
         ).sessionId
-        if (newSessionId == null) {
-            throw Exception("Session ID is null")
-        } else {
-            userPreferencesRepository.setSessionId(newSessionId)
-        }
+        userPreferencesRepository.setSessionId(newSessionId!!)
     }
 
     suspend fun getSessionId(): String? = userPreferencesRepository.sessionIdFlow.firstOrNull()
@@ -53,11 +48,6 @@ class GETAccountRepository @Inject constructor(
     suspend fun isLoggedIn(): Boolean =
         userPreferencesRepository.isLoggedInFlow.firstOrNull() ?: false
 
-    private suspend fun <T> tryRequestWithResult(request: suspend () -> T): Result<T> =
-        tryRequestWithTokenRefresh(
-            request = request,
-            refreshTokens = authTokenRepository::refreshTokens
-        )
 }
 
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/GETAccountRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/GETAccountRepository.kt
@@ -32,8 +32,8 @@ class GETAccountRepository @Inject constructor(
     suspend fun refreshLogin(pin: Int): Result<Unit> = resultOfNetworkCall {
         val newSessionId = networkApi.refreshAuthorizedUser(
             loginPIN = LoginPIN(pin.toString())
-        ).sessionId
-        userPreferencesRepository.setSessionId(newSessionId!!)
+        ).sessionId ?: throw IllegalStateException("Session ID is null")
+        userPreferencesRepository.setSessionId(newSessionId)
     }
 
     suspend fun getSessionId(): String? = userPreferencesRepository.sessionIdFlow.firstOrNull()

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/RepositoryRequestUtils.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/RepositoryRequestUtils.kt
@@ -2,6 +2,7 @@ package com.cornellappdev.android.eatery.data.repositories
 
 import com.cornellappdev.android.eatery.data.models.NetworkError
 import com.cornellappdev.android.eatery.data.models.Result
+import kotlinx.coroutines.CancellationException
 import retrofit2.HttpException
 import java.io.IOException
 import java.net.SocketTimeoutException
@@ -12,6 +13,8 @@ import java.net.SocketTimeoutException
 internal suspend fun <T> resultOfNetworkCall(request: suspend () -> T): Result<T> {
     return try {
         Result.Success(request())
+    } catch (ce: CancellationException) {
+        throw ce
     } catch (exception: Exception) {
         val networkError = when (exception) {
             is HttpException -> when (exception.code()) {

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/RepositoryRequestUtils.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/RepositoryRequestUtils.kt
@@ -6,49 +6,24 @@ import retrofit2.HttpException
 import java.io.IOException
 import java.net.SocketTimeoutException
 
-internal suspend fun <T> safeNetworkRequest(request: suspend () -> T): Result<T> {
+/**
+ * Wraps a suspend network request in a [Result] and maps thrown exceptions to [NetworkError]s.
+ */
+internal suspend fun <T> resultOfNetworkCall(request: suspend () -> T): Result<T> {
     return try {
         Result.Success(request())
     } catch (exception: Exception) {
-        Result.Error(mapExceptionToNetworkError(exception))
-    }
-}
-
-internal suspend fun <T> tryRequestWithTokenRefresh(
-    request: suspend () -> T,
-    refreshTokens: suspend () -> Result<Unit>
-): Result<T> {
-    return try {
-        Result.Success(request())
-    } catch (initialException: Exception) {
-        // Only attempt refresh for auth-related errors
-        val initialError = mapExceptionToNetworkError(initialException)
-        if (initialError !is NetworkError.Unauthorized) {
-            return Result.Error(initialError)
-        }
-        when (val refreshResult = refreshTokens()) {
-            is Result.Success -> {
-                try {
-                    Result.Success(request())
-                } catch (retryException: Exception) {
-                    Result.Error(mapExceptionToNetworkError(retryException))
-                }
+        val networkError = when (exception) {
+            is HttpException -> when (exception.code()) {
+                401, 403 -> NetworkError.Unauthorized
+                in 400..599 -> NetworkError.ServerError(exception.code(), exception.message())
+                else -> NetworkError.Unknown(exception)
             }
 
-            is Result.Error -> Result.Error(refreshResult.error)
+            is SocketTimeoutException -> NetworkError.Timeout
+            is IOException -> NetworkError.NetworkFailure
+            else -> NetworkError.Unknown(exception)
         }
+        Result.Error(networkError)
     }
 }
-
-private fun mapExceptionToNetworkError(exception: Exception): NetworkError = when (exception) {
-    is HttpException -> when (exception.code()) {
-        401, 403 -> NetworkError.Unauthorized
-        in 400..599 -> NetworkError.ServerError(exception.code(), exception.message())
-        else -> NetworkError.Unknown(exception)
-    }
-
-    is SocketTimeoutException -> NetworkError.Timeout
-    is IOException -> NetworkError.NetworkFailure
-    else -> NetworkError.Unknown(exception)
-}
-

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/UserRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/UserRepository.kt
@@ -166,7 +166,8 @@ class UserRepository @Inject constructor(
             )
         } catch (_: Exception) {
             val pin = getAccountRepository.getPin() ?: throw IllegalStateException()
-            getAccountRepository.refreshLogin(pin = pin)
+            val refreshResult = getAccountRepository.refreshLogin(pin = pin)
+            if (refreshResult is Result.Error) throw IllegalStateException("refreshLogin failed")
             financials = networkApi.getFinancials(
                 sessionId = SessionID(getAccountRepository.getSessionId())
             )

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/UserRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/UserRepository.kt
@@ -26,7 +26,6 @@ import javax.inject.Singleton
 class UserRepository @Inject constructor(
     private val networkApi: NetworkApi,
     private val userPreferencesRepository: UserPreferencesRepository,
-    private val authTokenRepository: AuthTokenRepository,
     private val getAccountRepository: GETAccountRepository
 ) {
     private val _loadedUser: MutableStateFlow<User?> = MutableStateFlow(null)
@@ -61,7 +60,7 @@ class UserRepository @Inject constructor(
             return Result.Success(Unit)
         }
 
-        return tryRequestWithResult {
+        return resultOfNetworkCall {
             val matches = networkApi.getFavoriteMatches()
             _favoriteEateriesFlow.value = matches.mapNotNull { it.eateryName }
             _favoriteItemsFlow.value = run {
@@ -73,7 +72,7 @@ class UserRepository @Inject constructor(
     }
 
     suspend fun sendReport(issue: String, report: String, eateryID: Int?): Result<Any> =
-        tryRequestWithResult {
+        resultOfNetworkCall {
             networkApi.sendReport(
                 report = ReportSendBody(
                     eatery = eateryID,
@@ -91,7 +90,7 @@ class UserRepository @Inject constructor(
             return Result.Success(Unit)
         }
 
-        return tryRequestWithResult {
+        return resultOfNetworkCall {
             networkApi.addFavoriteItem(
                 item = FavoriteItem(item = name)
             )
@@ -110,7 +109,7 @@ class UserRepository @Inject constructor(
             return Result.Success(Unit)
         }
 
-        return tryRequestWithResult {
+        return resultOfNetworkCall {
             networkApi.deleteFavoriteItem(
                 item = FavoriteItem(name)
             )
@@ -129,7 +128,7 @@ class UserRepository @Inject constructor(
             return Result.Success(Unit)
         }
 
-        return tryRequestWithResult {
+        return resultOfNetworkCall {
             networkApi.addFavoriteEatery(
                 eatery = FavoriteEatery(id),
             )
@@ -148,7 +147,7 @@ class UserRepository @Inject constructor(
             return Result.Success(Unit)
         }
 
-        return tryRequestWithResult {
+        return resultOfNetworkCall {
             networkApi.deleteFavoriteEatery(
                 eatery = FavoriteEatery(id)
             )
@@ -159,7 +158,7 @@ class UserRepository @Inject constructor(
     }
 
 
-    suspend fun getFinancials(): Result<Financials> = tryRequestWithResult {
+    suspend fun getFinancials(): Result<Financials> = resultOfNetworkCall {
         var financials: Financials
         try {
             financials = networkApi.getFinancials(
@@ -215,10 +214,4 @@ class UserRepository @Inject constructor(
 
     suspend fun hasOnboarded(): Boolean =
         userPreferencesRepository.hasOnboardedFlow.firstOrNull() ?: false
-
-    private suspend fun <T> tryRequestWithResult(request: suspend () -> T): Result<T> =
-        tryRequestWithTokenRefresh(
-            request = request,
-            refreshTokens = authTokenRepository::refreshTokens
-        )
 }


### PR DESCRIPTION
## Overview
The current authentication has two issues: 
- There are two layers of requesting auth tokens (at the interceptor and at individual calls)
- The code is bloated and hard to read.

This PR delegates the AuthInterceptor to handle all things auth token, so individual network calls don't need to worry about them. The only tokens of concern should be GET tokens. 

Additional simplifying changes were made for code clarity and cleanliness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for protected-request failures by treating additional HTTP responses as refresh-triggering and returning clearer failure responses when refresh fails.

* **Refactor**
  * Consolidated token persistence and simplified token acquisition/refresh flows.
  * Centralized network-call error mapping and removed automatic token-refresh retries from repository-level request wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->