### PR TITLE
Material 3 UI Fixes

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MealBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MealBottomSheet.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.cornellappdev.android.eatery.R
@@ -37,6 +38,7 @@ import com.cornellappdev.android.eatery.ui.components.general.MealFilter
 import com.cornellappdev.android.eatery.ui.theme.EateryBlue
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eatery.ui.theme.GrayZero
+import com.cornellappdev.android.eatery.util.EateryPreview
 
 /**
  * The pop-up that shows up when users want to pick a different meal as the filter in the upcoming
@@ -118,11 +120,13 @@ fun MealBottomSheet(
                 Icon(
                     painter = painterResource(id = R.drawable.ic_selected),
                     contentDescription = stringResource(R.string.a11y_meal_selected_breakfast),
+                    tint = Color.Unspecified
                 )
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_unselected),
                     contentDescription = stringResource(R.string.a11y_meal_select_breakfast),
+                    tint = Color.Unspecified
                 )
             }
         }
@@ -168,11 +172,13 @@ fun MealBottomSheet(
                 Icon(
                     painter = painterResource(id = R.drawable.ic_selected),
                     contentDescription = stringResource(R.string.a11y_meal_selected_lunch),
+                    tint = Color.Unspecified
                 )
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_unselected),
                     contentDescription = stringResource(R.string.a11y_meal_select_lunch),
+                    tint = Color.Unspecified
                 )
             }
         }
@@ -218,11 +224,13 @@ fun MealBottomSheet(
                 Icon(
                     painter = painterResource(id = R.drawable.ic_selected),
                     contentDescription = stringResource(R.string.a11y_meal_selected_dinner),
+                    tint = Color.Unspecified
                 )
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_unselected),
                     contentDescription = stringResource(R.string.a11y_meal_select_dinner),
+                    tint = Color.Unspecified
                 )
             }
         }
@@ -267,11 +275,13 @@ fun MealBottomSheet(
                 Icon(
                     painter = painterResource(id = R.drawable.ic_selected),
                     contentDescription = stringResource(R.string.a11y_meal_selected_late_dinner),
+                    tint = Color.Unspecified
                 )
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_unselected),
                     contentDescription = stringResource(R.string.a11y_meal_select_late_dinner),
+                    tint = Color.Unspecified
                 )
             }
         }
@@ -312,4 +322,15 @@ fun MealBottomSheet(
             color = Color.Black
         )
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MealBottomSheetPreview() = EateryPreview {
+    MealBottomSheet(
+        isVisible = true,
+        selectedMeal = MealFilter.LUNCH,
+        onSubmit = {},
+        hide = {}
+    )
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Theme.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Theme.kt
@@ -61,7 +61,7 @@ fun EateryBlueTheme(
 
     // For bottom sheet background colors
     val colorScheme = baseColorScheme.copy(
-        surface = Color.White,
+//        surface = Color.White,
         surfaceContainerLowest = Color.White,
         surfaceContainerLow = Color.White,
         surfaceContainer = Color.White,

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Theme.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Theme.kt
@@ -61,7 +61,6 @@ fun EateryBlueTheme(
 
     // For bottom sheet background colors
     val colorScheme = baseColorScheme.copy(
-//        surface = Color.White,
         surfaceContainerLowest = Color.White,
         surfaceContainerLow = Color.White,
         surfaceContainer = Color.White,

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Theme.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Theme.kt
@@ -46,7 +46,7 @@ fun EateryBlueTheme(
     dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
+    val baseColorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
             dynamicLightColorScheme(context)
@@ -58,6 +58,16 @@ fun EateryBlueTheme(
         darkTheme -> LightColorScheme
         else -> LightColorScheme
     }
+
+    // For bottom sheet background colors
+    val colorScheme = baseColorScheme.copy(
+        surface = Color.White,
+        surfaceContainerLowest = Color.White,
+        surfaceContainerLow = Color.White,
+        surfaceContainer = Color.White,
+        surfaceContainerHigh = Color.White,
+        surfaceContainerHighest = Color.White
+    )
 
     MaterialTheme(
         colorScheme = colorScheme,


### PR DESCRIPTION
## Overview
This PR fixes two known UI issues that arose from #221 (Material 3 migration). Namely,
- incorrect bottom sheet background color
-  meal bottom sheet selected icon being a filled circle when selected

## Changes Made
- Edit theme color scheme to default `Surface` background color to white
- Set tint to be unspecified for `MealBottomSheet` icons
- Create a preview for `MealBottomSheet`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined meal selection icon appearance for consistent visual presentation.
  * Standardized surface background colors to white across bottom sheets and interface elements for a unified look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->