### PR TITLE
Fix dark mode visual bugs (stacked on Brian_DarkMode)

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/comparemenus/CompareMenusBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/comparemenus/CompareMenusBottomSheet.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -43,8 +42,6 @@ import com.cornellappdev.android.eatery.ui.viewmodels.CompareMenusBottomViewMode
 import com.cornellappdev.android.eatery.util.DualModePreview
 import com.cornellappdev.android.eatery.util.EateryPreview
 import com.cornellappdev.android.eatery.util.PreviewData
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 @Composable
 fun CompareMenusBottomSheet(
@@ -150,14 +147,10 @@ fun CompareMenusBottomSheetContent(
         }
 
         Spacer(modifier = Modifier.height(12.dp))
-        val coroutineScope = rememberCoroutineScope()
         val canCompare = selectedEateries.size >= 2
         Button(
             onClick = {
-                coroutineScope.launch {
-                    delay(100)
-                    onCompareMenusClick(selectedEateries.mapNotNull { it.id })
-                }
+                onCompareMenusClick(selectedEateries.mapNotNull { it.id })
             },
             enabled = canCompare,
             modifier = Modifier

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryDetailsStickyHeader.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryDetailsStickyHeader.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.cornellappdev.android.eatery.data.models.Event
-import com.cornellappdev.android.eatery.data.models.MenuCategory
 import com.cornellappdev.android.eatery.ui.theme.currentColors
 import kotlinx.coroutines.launch
 
@@ -45,25 +44,50 @@ fun EateryDetailsStickyHeader(
 ) {
     val rowState = rememberLazyListState()
     val rowCoroutine = rememberCoroutineScope()
-    val selectedEvent = nextEvent?.menu?.find { category ->
-        highlightCategory(
-            category,
-            listState,
-            nextEvent,
-            fullMenuList,
-            startIndex
-        )
-    }
-    val selectedIndex: Int =
-        if (selectedEvent != null) nextEvent.menu.indexOf(selectedEvent) else -1
 
-    // Whenever the selected index changes, scroll to the new item.
+    val highlightedCategoryName by remember(nextEvent, fullMenuList, startIndex) {
+        derivedStateOf {
+            val menu = nextEvent?.menu ?: return@derivedStateOf null
+            val visibleItems = listState.layoutInfo.visibleItemsInfo
+            val canScrollForward = listState.canScrollForward
+
+            if (!canScrollForward && visibleItems.isNotEmpty()) {
+                // At the bottom of the list: highlight the last visible category so pills
+                // advance past whichever category is at the top of the viewport.
+                visibleItems.reversed().firstNotNullOfOrNull { info ->
+                    val idx = info.index - startIndex
+                    fullMenuList.getOrNull(idx)?.takeIf { name ->
+                        menu.any { it.name == name }
+                    }
+                }
+            } else {
+                val firstMenuItemIndex = listState.firstVisibleItemIndex - startIndex
+                if (firstMenuItemIndex >= 0 && firstMenuItemIndex < fullMenuList.size) {
+                    val item = fullMenuList[firstMenuItemIndex]
+                    val isCategoryName = menu.any { it.name == item }
+                    if (isCategoryName) {
+                        item
+                    } else {
+                        (firstMenuItemIndex - 1 downTo 0).firstNotNullOfOrNull { i ->
+                            fullMenuList.getOrNull(i)?.takeIf { name ->
+                                menu.any { it.name == name }
+                            }
+                        }
+                    }
+                } else null
+            }
+        }
+    }
+
+    val selectedIndex =
+        nextEvent?.menu?.indexOfFirst { it.name == highlightedCategoryName } ?: -1
+
+    // Whenever the selected index changes, scroll the pill row to the new item.
     LaunchedEffect(selectedIndex) {
         if (selectedIndex != -1)
             rowCoroutine.launch {
                 if (selectedIndex >= 4) {
-                    // They've scrolled decently far down and have interacted with this menu, we can
-                    // request a review
+                    // They've scrolled decently far down — good time to request a review.
                     onRequestRatingPopup()
                 }
                 rowState.animateScrollToItem(selectedIndex)
@@ -76,7 +100,6 @@ fun EateryDetailsStickyHeader(
                 .fillMaxWidth()
                 .background(currentColors.backgroundDefault)
         ) {
-
             Spacer(modifier = Modifier.height(6.dp))
 
             val filteredItemsList = nextEvent?.menu?.mapNotNull { category ->
@@ -103,16 +126,9 @@ fun EateryDetailsStickyHeader(
                     nextEvent?.menu?.forEach { category ->
                         item {
                             val categoryIndex = fullMenuList.indexOf(category.name)
-                            val isHighlighted = highlightCategory(
-                                category,
-                                listState,
-                                nextEvent,
-                                fullMenuList,
-                                startIndex
-                            )
                             CategoryItem(
-                                category.name ?: "Category",
-                                isHighlighted,
+                                name = category.name ?: "Category",
+                                isHighlighted = category.name == highlightedCategoryName,
                             ) { onItemClick(categoryIndex) }
                         }
                         item {
@@ -177,38 +193,4 @@ fun CategoryItem(
             )
         )
     }
-}
-
-/**
- * Returns true if the given menu category should be highlighted (i.e. it is scrolled to).
- */
-@Composable
-fun highlightCategory(
-    category: MenuCategory,
-    listState: LazyListState,
-    nextEvent: Event?,
-    fullMenuList: MutableList<String>,
-    startIndex: Int
-): Boolean {
-    val firstVisibleState = remember { derivedStateOf { listState.firstVisibleItemIndex } }
-    // Note: - 5 here assumes that there are 5 UI elements above the menu, which is true currently.
-    //  If that changes, this must be tweaked.
-    val firstMenuItemIndex = firstVisibleState.value - startIndex
-
-    if (firstMenuItemIndex >= 0 && firstMenuItemIndex < fullMenuList.size) {
-        val item = fullMenuList[firstMenuItemIndex]
-        val isCategoryName = nextEvent?.menu?.any { it.name == item } ?: false
-
-        if (isCategoryName) {
-            return category.name == item
-        } else {
-            for (i in firstMenuItemIndex - 1 downTo 0) {
-                val previousItem = fullMenuList[i]
-                if (nextEvent?.menu?.any { it.name == previousItem } == true) {
-                    return category.name == previousItem
-                }
-            }
-        }
-    }
-    return false
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryHourBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/EateryHourBottomSheet.kt
@@ -101,7 +101,7 @@ fun EateryHourBottomSheet(
                 fontWeight = FontWeight.SemiBold, fontSize = 16.sp
             ),
             color = if (openUntil == null) currentColors.error
-            else if (eatery.isClosingSoon()) currentColors.accentPressed
+            else if (eatery.isClosingSoon()) currentColors.warning
             else currentColors.success
         )
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/FavoritesToggle.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/FavoritesToggle.kt
@@ -1,26 +1,24 @@
 package com.cornellappdev.android.eatery.ui.components.details
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eatery.ui.theme.currentColors
 import com.cornellappdev.android.eatery.util.DualModePreview
@@ -30,44 +28,49 @@ import com.cornellappdev.android.eatery.util.EateryPreview
 fun FavoritesToggle(
     onClick: () -> Unit,
     label: String,
-    active: Boolean
+    active: Boolean,
+    modifier: Modifier = Modifier
 ) {
-    val detailColor = if (active) currentColors.contentBrand else currentColors.textSecondary
-    val backgroundColor = if (active) currentColors.backgroundDefault else Color.Transparent
-    Row(
-        modifier = Modifier
-            .clip(RoundedCornerShape(8))
-            .clickable { onClick() }
-            .border(BorderStroke(Dp.Hairline, detailColor), RoundedCornerShape(8))
-            .background(backgroundColor)
-            .padding(vertical = 8.dp, horizontal = 10.dp)
-            .size(width = 160.dp, height = 18.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center // Center content within the Row
+    val borderColor = if (active) currentColors.borderBlue else currentColors.accentPrimary
+    val textColor = if (active) currentColors.contentBrand else currentColors.textSecondary
+    val shape = RoundedCornerShape(8.dp)
+    Button(
+        onClick = onClick,
+        modifier = modifier
+            .shadow(elevation = if (active) 4.dp else 0.dp, shape = shape),
+        shape = shape,
+        border = BorderStroke(Dp.Hairline, borderColor),
+        contentPadding = PaddingValues(vertical = 8.dp, horizontal = 10.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = currentColors.backgroundDefault,
+            contentColor = textColor
+        )
     ) {
         Text(
             text = label,
-            color = detailColor,
+            color = textColor,
             style = EateryBlueTypography.button
         )
     }
-
 }
 
 @Composable
 fun ToggleRow(toggle: Boolean, setToggle: (Boolean) -> Unit) {
     Row(
-        horizontalArrangement = (Arrangement.spacedBy(8.dp))
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         FavoritesToggle(
             onClick = { setToggle(true) },
             label = "Eateries",
-            active = toggle
+            active = toggle,
+            modifier = Modifier.weight(1f)
         )
         FavoritesToggle(
             onClick = { setToggle(false) },
             label = "Items",
-            active = !toggle
+            active = !toggle,
+            modifier = Modifier.weight(1f)
         )
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/FavoritesToggle.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/FavoritesToggle.kt
@@ -15,8 +15,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
@@ -36,10 +34,9 @@ fun FavoritesToggle(
     val shape = RoundedCornerShape(8.dp)
     Button(
         onClick = onClick,
-        modifier = modifier
-            .shadow(elevation = if (active) 4.dp else 0.dp, shape = shape),
+        modifier = modifier,
         shape = shape,
-        border = BorderStroke(Dp.Hairline, borderColor),
+        border = BorderStroke(1.dp, borderColor),
         contentPadding = PaddingValues(vertical = 8.dp, horizontal = 10.dp),
         colors = ButtonDefaults.buttonColors(
             containerColor = currentColors.backgroundDefault,

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/ItemFavoritesCard.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/ItemFavoritesCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -21,7 +22,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.Dp
@@ -57,7 +57,7 @@ fun ItemFavoritesCard(
         modifier = modifier
             .fillMaxWidth()
             .border(
-                BorderStroke(Dp.Hairline, currentColors.backgroundDefault92),
+                BorderStroke(Dp.Hairline, currentColors.accentPrimary),
                 RoundedCornerShape(8)
             ),
         shape = RoundedCornerShape(8.dp),
@@ -81,7 +81,10 @@ fun ItemFavoritesCard(
                     viewState.itemName,
                     fontSize = 20.sp,
                     style = EateryBlueTypography.button,
-                    color = currentColors.textPrimary
+                    color = currentColors.textPrimary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
                 )
                 FavoriteButton(isFavorite = true, onFavoriteClick = { onFavoriteClick() })
             }
@@ -103,13 +106,14 @@ fun ItemFavoritesCard(
                     Icon(
                         imageVector = ImageVector.vectorResource(id = R.drawable.ic_down_chevron),
                         contentDescription = "expand",
+                        tint = currentColors.textPrimary,
                         modifier = Modifier.rotate(rotation)
                     )
                 }
 
             }
             if (isExpanded) {
-                HorizontalDivider(thickness = Dp.Hairline)
+                HorizontalDivider(thickness = Dp.Hairline, color = currentColors.borderDefault)
                 viewState.mealAvailability.forEach { availability ->
                     ItemInformation(availability.key, availability.value)
                 }
@@ -130,7 +134,7 @@ fun ItemInformation(meal: String, eateryName: List<String>) {
             color = currentColors.textPrimary
         )
         eateryName.forEach { eatery ->
-            Text(eatery, style = EateryBlueTypography.caption, color = Color(0xff7D8288))
+            Text(eatery, style = EateryBlueTypography.caption, color = currentColors.textSecondary)
         }
     }
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/ItemFavoritesCard.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/ItemFavoritesCard.kt
@@ -1,3 +1,5 @@
+package com.cornellappdev.android.eatery.ui.components.details
+
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
@@ -57,12 +59,12 @@ fun ItemFavoritesCard(
         modifier = modifier
             .fillMaxWidth()
             .border(
-                BorderStroke(Dp.Hairline, currentColors.accentPrimary),
+                BorderStroke(Dp.Hairline, currentColors.borderDefault),
                 RoundedCornerShape(8)
             ),
         shape = RoundedCornerShape(8.dp),
         colors = CardDefaults.cardColors(
-            containerColor = currentColors.backgroundDefault
+            containerColor = currentColors.accentPrimary
         ),
         elevation = CardDefaults.cardElevation(8.dp)
     ) {
@@ -79,8 +81,7 @@ fun ItemFavoritesCard(
             ) {
                 Text(
                     viewState.itemName,
-                    fontSize = 20.sp,
-                    style = EateryBlueTypography.button,
+                    style = EateryBlueTypography.h5,
                     color = currentColors.textPrimary,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
@@ -129,8 +130,7 @@ fun ItemInformation(meal: String, eateryName: List<String>) {
     ) {
         Text(
             meal,
-            fontSize = 20.sp,
-            style = EateryBlueTypography.button,
+            style = EateryBlueTypography.h5,
             color = currentColors.textPrimary
         )
         eateryName.forEach { eatery ->

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/PaymentWidgets.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/details/PaymentWidgets.kt
@@ -17,6 +17,7 @@ import com.cornellappdev.android.eatery.data.models.PaymentMethod
 import com.cornellappdev.android.eatery.ui.components.general.PaymentMethodsAvailable
 import com.cornellappdev.android.eatery.ui.components.general.isAcceptedBy
 import com.cornellappdev.android.eatery.ui.components.general.tintColor
+import com.cornellappdev.android.eatery.ui.theme.currentColors
 import com.cornellappdev.android.eatery.util.DualModePreview
 import com.cornellappdev.android.eatery.util.EateryPreview
 import com.cornellappdev.android.eatery.util.PreviewData
@@ -29,7 +30,9 @@ fun PaymentWidgets(eatery: Eatery, modifier: Modifier = Modifier, onClick: () ->
     Surface(
         modifier = modifier.clickable {
             onClick.invoke()
-        }, shape = CircleShape
+        },
+        shape = CircleShape,
+        color = currentColors.accentPrimary
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/EateryCard.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/EateryCard.kt
@@ -271,7 +271,7 @@ fun GridViewFavoriteWidget(
     ) {
         Icon(
             imageVector = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
-            tint = if (isFavorite) currentColors.accentPressed else currentColors.textSecondary,
+            tint = if (isFavorite) currentColors.favorite else currentColors.textSecondary,
             modifier = Modifier
                 .padding(8.dp),
             contentDescription = null
@@ -328,7 +328,7 @@ fun EateryCardSecondaryHeader(eatery: Eatery, style: EateryCardStyle = EateryCar
                     else ("Open until $openUntil"),
                 style = EateryBlueTypography.subtitle2,
                 color = if (openUntil == null) currentColors.error
-                else if (eatery.isClosingSoon()) currentColors.accentPressed
+                else if (eatery.isClosingSoon()) currentColors.warning
                 else currentColors.success
             )
         }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/FilterRow.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/FilterRow.kt
@@ -35,10 +35,11 @@ fun FilterRow(
     customItemsBefore: LazyListScope.() -> Unit = {},
     customItemsAfter: LazyListScope.() -> Unit = {},
     rowState: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp),
 ) {
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
-        contentPadding = PaddingValues(horizontal = 16.dp),
+        contentPadding = contentPadding,
         state = rowState
     ) {
         customItemsBefore()

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/FilterRow.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/general/FilterRow.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
@@ -38,6 +39,7 @@ fun FilterRow(
     contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp),
 ) {
     LazyRow(
+        modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         contentPadding = contentPadding,
         state = rowState

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/login/AccountPage.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/login/AccountPage.kt
@@ -329,7 +329,7 @@ private fun AccountPageHeader(
                             modifier = Modifier.size(28.dp),
                             imageVector = Icons.Outlined.Settings,
                             contentDescription = stringResource(R.string.a11y_settings),
-                            tint = Color.White
+                            tint = currentColors.oppTextPrimary
                         )
                     }
                 }
@@ -349,7 +349,7 @@ private fun AccountPageHeader(
                             modifier = Modifier.size(28.dp),
                             imageVector = Icons.Outlined.Settings,
                             contentDescription = stringResource(R.string.a11y_settings),
-                            tint = currentColors.textPrimary
+                            tint = currentColors.oppTextPrimary
                         )
                     }
                     Text(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/login/AccountPage.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/login/AccountPage.kt
@@ -329,7 +329,7 @@ private fun AccountPageHeader(
                             modifier = Modifier.size(28.dp),
                             imageVector = Icons.Outlined.Settings,
                             contentDescription = stringResource(R.string.a11y_settings),
-                            tint = currentColors.oppTextPrimary
+                            tint = Color.White
                         )
                     }
                 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/login/LoginPage.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/login/LoginPage.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.zIndex
 import com.cornellappdev.android.eatery.BuildConfig
 import com.cornellappdev.android.eatery.R
+import com.cornellappdev.android.eatery.ui.theme.BorderBlueLight
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eatery.ui.theme.currentColors
 import com.cornellappdev.android.eatery.util.DualModePreview
@@ -181,7 +182,7 @@ private fun LoginPageMainLayer(
                     modifier = Modifier
                         .fillMaxWidth(0.5f)
                         .fillMaxHeight(),
-                    colorFilter = ColorFilter.tint(Color(0xFFB7D3F3))
+                    colorFilter = ColorFilter.tint(BorderBlueLight)
                 )
             }
             Button(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MenuCard.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/upcoming/MenuCard.kt
@@ -72,7 +72,7 @@ fun MenuCard(
     Card(
         elevation = CardDefaults.cardElevation(defaultElevation = 5.dp),
         shape = RoundedCornerShape(10.dp),
-        colors = CardDefaults.cardColors(containerColor = currentColors.backgroundDefault),
+        colors = CardDefaults.cardColors(containerColor = currentColors.accentPrimary),
         modifier = Modifier.clickable {
             openDropdown = !openDropdown
             if (!openDropdown) onEateryCardContract()

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/CompareMenusScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/CompareMenusScreen.kt
@@ -18,19 +18,18 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerDefaults
 import androidx.compose.foundation.pager.PagerSnapDistance
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
+import androidx.compose.material3.Surface
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -57,6 +56,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -392,12 +392,8 @@ private fun MenuPager(
                 if (currentEvent != null) {
                     Box(
                         modifier = Modifier
-                            .background(currentColors.backgroundDefault)
-                            .padding(
-                                start = 8.dp,
-                                end = 8.dp,
-                                top = 20.dp
-                            )
+                            .background(currentColors.accentPrimary)
+                            .padding(8.dp)
                             .fillMaxWidth()
                             .fillMaxHeight()
                     ) {
@@ -405,134 +401,104 @@ private fun MenuPager(
                             state = listState,
                             modifier = Modifier
                                 .fillMaxSize()
-                                .background(currentColors.backgroundDefault)
+                                .background(currentColors.accentPrimary),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             currentEvent.menu?.forEach { category ->
                                 item {
-                                    Text(
-                                        text = category.name ?: "Category",
-                                        style = EateryBlueTypography.h5,
-                                        modifier = Modifier.padding(
-                                            horizontal = 16.dp,
-                                            vertical = 12.dp
-                                        ),
-                                        color = currentColors.textPrimary
-                                    )
-                                }
-
-                                itemsIndexed(
-                                    category.items ?: emptyList()
-                                ) { index, menuItem ->
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        modifier = Modifier.padding(
-                                            top = 12.dp,
-                                            bottom = 12.dp,
-                                            start = 16.dp,
-                                            end = 16.dp
-                                        ),
-                                        horizontalArrangement = Arrangement.SpaceBetween
+                                    Surface(
+                                        shape = RoundedCornerShape(8.dp),
+                                        color = currentColors.backgroundDefault,
+                                        modifier = Modifier.fillMaxWidth()
                                     ) {
-                                        Text(
-                                            text = menuItem.name ?: "Item Name",
-                                            style = EateryBlueTypography.button,
-                                            modifier = Modifier.weight(1f),
-                                            color = currentColors.textPrimary
-                                        )
-                                    }
-
-                                    if (category.items?.lastIndex != index) {
-                                        Spacer(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .height(1.dp)
-                                                .background(
-                                                    currentColors.borderDefault,
-                                                    CircleShape
-                                                )
-                                        )
-                                    }
-                                    if (category.items?.lastIndex == index) {
-                                        HorizontalDivider(
-                                            thickness = 10.dp,
-                                            color = currentColors.borderDefault
-                                        )
+                                        Column {
+                                            Text(
+                                                text = category.name ?: "Category",
+                                                style = EateryBlueTypography.h5,
+                                                modifier = Modifier.padding(
+                                                    horizontal = 16.dp,
+                                                    vertical = 12.dp
+                                                ),
+                                                color = currentColors.textPrimary
+                                            )
+                                            category.items?.forEachIndexed { index, menuItem ->
+                                                if (index > 0) {
+                                                    HorizontalDivider(
+                                                        thickness = Dp.Hairline,
+                                                        color = currentColors.borderDefault
+                                                    )
+                                                }
+                                                Row(
+                                                    verticalAlignment = Alignment.CenterVertically,
+                                                    modifier = Modifier.padding(
+                                                        horizontal = 16.dp,
+                                                        vertical = 12.dp
+                                                    ),
+                                                    horizontalArrangement = Arrangement.SpaceBetween
+                                                ) {
+                                                    Text(
+                                                        text = menuItem.name ?: "Item Name",
+                                                        style = EateryBlueTypography.button,
+                                                        modifier = Modifier.weight(1f),
+                                                        color = currentColors.textPrimary
+                                                    )
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
                             if (currentEvent.menu.isNullOrEmpty()) {
                                 item {
-                                    Row(
-                                        modifier = Modifier
-                                            .background(currentColors.backgroundSurface)
-                                            .clip(
-                                                shape = RoundedCornerShape(
-                                                    12.dp
-                                                )
-                                            )
-                                            .fillMaxWidth()
-                                            .padding(
-                                                top = 12.dp,
-                                                bottom = 12.dp
-                                            ),
-                                        horizontalArrangement = Arrangement.Center
+                                    Surface(
+                                        shape = RoundedCornerShape(8.dp),
+                                        color = currentColors.backgroundDefault,
+                                        modifier = Modifier.fillMaxWidth()
                                     ) {
-                                        Text(
-                                            text = stringResource(R.string.compare_menus_no_menu),
-                                            color = currentColors.textPrimary,
-                                            style = EateryBlueTypography.h5,
-                                            modifier = Modifier.padding(start = 8.dp),
-                                            fontWeight = FontWeight(500),
-                                        )
+                                        Row(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(vertical = 12.dp),
+                                            horizontalArrangement = Arrangement.Center
+                                        ) {
+                                            Text(
+                                                text = stringResource(R.string.compare_menus_no_menu),
+                                                color = currentColors.textPrimary,
+                                                style = EateryBlueTypography.h5,
+                                                modifier = Modifier.padding(start = 8.dp),
+                                                fontWeight = FontWeight(500),
+                                            )
+                                        }
                                     }
-                                    HorizontalDivider(
-                                        color = currentColors.borderDefault,
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .height(10.dp)
-                                    )
                                 }
                             }
                             item {
-                                Column(modifier = Modifier.background(currentColors.backgroundDefault)) {
-                                    Card(
-                                        shape = RoundedCornerShape(20.dp),
-                                        onClick = {
-                                            onEateryClick(eateries[page])
-                                        },
-                                        colors = CardDefaults.cardColors(containerColor = currentColors.accentPrimary),
+                                Card(
+                                    shape = RoundedCornerShape(100.dp),
+                                    onClick = {
+                                        onEateryClick(eateries[page])
+                                    },
+                                    colors = CardDefaults.cardColors(containerColor = currentColors.backgroundDefault),
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Row(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .padding(
-                                                top = 12.dp,
-                                                bottom = 12.dp,
-                                                start = 12.dp,
-                                                end = 12.dp
-                                            )
+                                            .padding(horizontal = 10.dp, vertical = 8.dp),
+                                        horizontalArrangement = Arrangement.Center,
+                                        verticalAlignment = Alignment.CenterVertically
                                     ) {
-                                        Row(
-                                            modifier = Modifier.padding(
-                                                end = 12.dp,
-                                                top = 10.dp,
-                                                bottom = 10.dp
-                                            ),
-                                            horizontalArrangement = Arrangement.Center
-                                        ) {
-                                            Icon(
-                                                painter = painterResource(R.drawable.ic_eatery),
-                                                contentDescription = null,
-                                                tint = currentColors.textPrimary
-                                            )
-                                            Text(
-                                                text = stringResource(R.string.view_eatery_details),
-                                                color = currentColors.textPrimary,
-                                                modifier = Modifier.padding(
-                                                    start = 8.dp,
-                                                ),
-                                                fontWeight = FontWeight.Bold,
-                                            )
-
-                                        }
+                                        Icon(
+                                            painter = painterResource(R.drawable.ic_eatery),
+                                            contentDescription = null,
+                                            tint = currentColors.textPrimary
+                                        )
+                                        Text(
+                                            text = stringResource(R.string.view_eatery_details),
+                                            color = currentColors.textPrimary,
+                                            modifier = Modifier.padding(start = 8.dp),
+                                            fontWeight = FontWeight.Bold,
+                                        )
                                     }
                                 }
                             }
@@ -581,7 +547,7 @@ private fun TitlePager(
                         style = EateryBlueTypography.button,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        color = currentColors.textPrimary
+                        color = if (page == secondPagerState.currentPage) currentColors.textPrimary else currentColors.textSecondary
                     )
                 }
             }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/CompareMenusScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/CompareMenusScreen.kt
@@ -17,7 +17,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerDefaults
@@ -79,7 +83,6 @@ import com.cornellappdev.android.eatery.util.EateryPreview
 import com.cornellappdev.android.eatery.util.PreviewData
 import com.cornellappdev.android.eatery.util.appStorePopupRepository
 import kotlinx.coroutines.launch
-import java.math.BigDecimal
 
 @OptIn(
     ExperimentalFoundationApi::class,
@@ -169,34 +172,6 @@ private fun CompareMenusScreenContent(
         )
         Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
         val firstPagerState = rememberPagerState(pageCount = { eateries.size })
-        val secondPagerState = rememberPagerState(pageCount = { eateries.size })
-
-        val scrollingFollowingPair by remember {
-            derivedStateOf {
-                if (firstPagerState.isScrollInProgress) {
-                    firstPagerState to secondPagerState
-                } else if (secondPagerState.isScrollInProgress) {
-                    secondPagerState to firstPagerState
-                } else null
-            }
-        }
-        LaunchedEffect(scrollingFollowingPair) {
-            val (scrollingState, followingState) = scrollingFollowingPair
-                ?: return@LaunchedEffect
-            snapshotFlow { scrollingState.currentPage + scrollingState.currentPageOffsetFraction }
-                .collect { pagePart ->
-                    val divideAndRemainder = BigDecimal.valueOf(pagePart.toDouble())
-                        .divideAndRemainder(BigDecimal.ONE)
-                    val pageOffsetFraction =
-                        if (divideAndRemainder[1].toFloat() > 0.5f) 0.5f else (-0.5f).coerceAtLeast(
-                            divideAndRemainder[1].toFloat()
-                        )
-                    followingState.scrollToPage(
-                        divideAndRemainder[0].toInt(),
-                        pageOffsetFraction,
-                    )
-                }
-        }
         if (showBottomSheet) {
             ModalBottomSheet(
                 onDismissRequest = closeBottomSheet,
@@ -249,7 +224,9 @@ private fun CompareMenusScreenContent(
                 onRequestRatingPopup = onRequestRatingPopup,
                 onEateryClick = onEateryClick
             )
-            TitlePager(eateries, secondPagerState)
+            TitlePager(eateries, firstPagerState) { page ->
+                coroutineScope.launch { firstPagerState.scrollToPage(page) }
+            }
         }
 
     }
@@ -299,12 +276,10 @@ private fun MenuPager(
         val listState = rememberLazyListState()
         Box {
             val currentEvent = events.getOrNull(page)
+            // Only category names: one LazyColumn item per category card, so index == category index
             val fullMenuList = mutableListOf<String>()
             currentEvent?.menu?.forEach { category ->
                 category.name?.let { fullMenuList.add(it) }
-                category.items?.forEach { item ->
-                    item.name?.let { fullMenuList.add(it) }
-                }
             }
             Column(modifier = Modifier.fillMaxSize()) {
                 Row(
@@ -517,38 +492,60 @@ private fun MenuPager(
 @OptIn(ExperimentalFoundationApi::class)
 private fun TitlePager(
     eateries: List<Eatery>,
-    secondPagerState: PagerState
+    pagerState: PagerState,
+    onPageSelected: (Int) -> Unit,
 ) {
-    HorizontalPager(
-        state = secondPagerState,
+    val rowState = rememberLazyListState()
+    val currentPage by remember { derivedStateOf { pagerState.currentPage } }
+
+    BoxWithConstraints(
         modifier = Modifier
-            .fillMaxSize()
-            .background(currentColors.backgroundDefault),
-        contentPadding = PaddingValues(horizontal = 100.dp),
-        pageSpacing = 2.dp,
-        verticalAlignment = Alignment.CenterVertically,
-        flingBehavior = PagerDefaults.flingBehavior(
-            state = secondPagerState,
-            //pager snap distance literally does nothing
-            pagerSnapDistance = PagerSnapDistance.atMost(1),
-        ),
-    ) { page ->
-        Column(modifier = Modifier.fillMaxHeight(), verticalArrangement = Arrangement.Center) {
-            Box(
-                modifier = Modifier
-                    .shadow(2.dp, shape = RoundedCornerShape(8.dp))
-                    .clip(shape = RoundedCornerShape(8.dp))
-                    .background(currentColors.backgroundDefault)
-                    .padding(vertical = 8.dp, horizontal = 16.dp)
-            ) {
-                eateries[page].name?.let {
-                    Text(
-                        text = it,
-                        style = EateryBlueTypography.button,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        color = if (page == secondPagerState.currentPage) currentColors.textPrimary else currentColors.textSecondary
-                    )
+            .fillMaxWidth()
+            .background(currentColors.backgroundDefault)
+            .padding(vertical = 8.dp)
+    ) {
+        // Each tab is 45% of viewport width; side padding centers each tab when scrolled to it.
+        // scrollOffset = -sidePaddingPx in animateScrollToItem positions the item's leading edge
+        // at sidePadding from the viewport left = centered.
+        val tabWidth = maxWidth * 0.45f
+        val sidePadding = (maxWidth - tabWidth) / 2
+
+        LaunchedEffect(pagerState) {
+            snapshotFlow { pagerState.currentPage }
+                .collect { page ->
+                    // contentPadding = sidePadding on both sides, so scrollOffset = 0 places
+                    // each item's leading edge at sidePadding from the viewport = centered.
+                    rowState.animateScrollToItem(index = page, scrollOffset = 0)
+                }
+        }
+
+        LazyRow(
+            state = rowState,
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(horizontal = sidePadding)
+        ) {
+            itemsIndexed(eateries) { index, eatery ->
+                val isSelected = index == currentPage
+                Box(
+                    modifier = Modifier
+                        .width(tabWidth)
+                        .shadow(if (isSelected) 2.dp else 0.dp, shape = RoundedCornerShape(8.dp))
+                        .clip(shape = RoundedCornerShape(8.dp))
+                        .background(currentColors.accentPrimary)
+                        .clickable { onPageSelected(index) }
+                        .padding(vertical = 8.dp, horizontal = 16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    eatery.name?.let {
+                        Text(
+                            text = it,
+                            style = EateryBlueTypography.button,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            color = if (isSelected) currentColors.textPrimary else currentColors.textSecondary
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/EateryDetailScreen.kt
@@ -67,8 +67,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -813,21 +811,20 @@ fun EateryDetailScreenContent(
                                     Spacer(Modifier.height(8.dp))
                                     //reporting button
                                     Button(
-                                        shape = RoundedCornerShape(24.dp),
-                                        modifier = Modifier
-                                            .height(35.dp)
-                                            .shadow(0.dp),
+                                        shape = RoundedCornerShape(100.dp),
+                                        modifier = Modifier.height(35.dp),
                                         onClick = {
                                             openBottomSheet(BottomSheetContent.REPORT)
                                         },
                                         colors = ButtonDefaults.buttonColors(
-                                            containerColor = currentColors.backgroundDefault,
+                                            containerColor = currentColors.accentPrimary,
+                                            contentColor = currentColors.textPrimary
                                         )
                                     ) {
                                         Icon(
                                             imageVector = Icons.Default.Report,
                                             contentDescription = Icons.Default.Report.name,
-                                            tint = Color.Unspecified
+                                            tint = currentColors.textPrimary
                                         )
                                         Spacer(Modifier.size(ButtonDefaults.IconSpacing))
                                         Text(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -106,7 +107,7 @@ private fun FavoritesScreenContent(
     Column(
         modifier = Modifier
             .background(color = currentColors.backgroundDefault)
-            .padding(horizontal = 10.dp)
+            .padding(horizontal = 16.dp)
             .then(Modifier.statusBarsPadding())
             .fillMaxSize()
     ) {
@@ -119,7 +120,8 @@ private fun FavoritesScreenContent(
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(id = R.drawable.ic_left_chevron),
-                    contentDescription = stringResource(R.string.back)
+                    contentDescription = stringResource(R.string.back),
+                    tint = currentColors.textPrimary
                 )
             }
             IconButton(
@@ -128,6 +130,7 @@ private fun FavoritesScreenContent(
                 Icon(
                     imageVector = ImageVector.vectorResource(id = R.drawable.ic_search),
                     contentDescription = stringResource(R.string.search),
+                    tint = currentColors.textPrimary
                 )
             }
 
@@ -271,7 +274,8 @@ private fun ColumnScope.MainScrollableContent(
                     favoritesScreenViewState.eateryFilters
                 } else {
                     favoritesScreenViewState.itemFilters
-                }
+                },
+                contentPadding = PaddingValues(0.dp)
             )
         }
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/FavoritesScreen.kt
@@ -1,6 +1,6 @@
 package com.cornellappdev.android.eatery.ui.screens
 
-import ItemFavoritesCard
+import com.cornellappdev.android.eatery.ui.components.details.ItemFavoritesCard
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SupportScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SupportScreen.kt
@@ -195,7 +195,7 @@ private fun SupportScreenContent(
             },
             colors = ButtonDefaults.buttonColors(
                 containerColor = currentColors.contentBrand,
-                contentColor = currentColors.backgroundDefault
+                contentColor = currentColors.oppTextPrimary
             )
         ) {
             Icon(imageVector = Icons.Default.Report, Icons.Default.Report.name)

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Color.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Color.kt
@@ -42,7 +42,7 @@ val TextSecondaryDark = Color(0xFF9EA8B5)
 
 // Accent colors
 val AccentPrimaryLight = Color(0xFFEFF1F4)
-val AccentPrimaryDark = Color(0xFF272727)
+val AccentPrimaryDark = Color(0xFF2E2E2E)
 
 val AccentPressedLight = Color(0xFFE8EFF8)
 val AccentPressedDark = Color(0xFF1C1C1C)

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Color.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Color.kt
@@ -51,6 +51,10 @@ val AccentPressedDark = Color(0xFF1C1C1C)
 val BorderDefaultLight = Color(0xFFE1E4E8)
 val BorderDefaultDark = Color(0xFF282828)
 
+// Blue border (active tab/toggle state)
+val BorderBlueLight = Color(0xFFB7D3F3)
+val BorderBlueDark = Color(0xFF1D4A7A)
+
 // Favorite colors
 val FavoriteLight = Color(0xFFFFD700)
 val FavoriteDark = Color(0xFFFFD700)
@@ -105,6 +109,7 @@ object ColorTheme
         accentPrimary = AccentPrimaryLight,
         accentPressed = AccentPressedLight,
         borderDefault = BorderDefaultLight,
+        borderBlue = BorderBlueLight,
         favorite = FavoriteLight,
         warning = WarningLight,
     )
@@ -124,6 +129,7 @@ object ColorTheme
         accentPrimary = AccentPrimaryDark,
         accentPressed = AccentPressedDark,
         borderDefault = BorderDefaultDark,
+        borderBlue = BorderBlueDark,
         favorite = FavoriteDark,
         warning = WarningDark,
     )
@@ -146,6 +152,7 @@ data class ColorMode(
     val accentPrimary : Color,
     val accentPressed: Color,
     val borderDefault: Color,
+    val borderBlue: Color,
     val favorite: Color,
     val warning: Color
 )

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Theme.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Theme.kt
@@ -13,7 +13,7 @@ val LocalColorMode = staticCompositionLocalOf { ColorTheme.lightMode }
 
 @Composable
 fun AppColorTheme(
-    colorMode: ColorMode ,
+    colorMode: ColorMode,
     content: @Composable () -> Unit
 ) {
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/FavoritesViewModel.kt
@@ -1,7 +1,8 @@
 package com.cornellappdev.android.eatery.ui.viewmodels
 
 import ItemFavoritesCardViewState
-import androidx.compose.ui.graphics.Color
+import com.cornellappdev.android.eatery.ui.theme.ErrorLight
+import com.cornellappdev.android.eatery.ui.theme.SuccessLight
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.android.eatery.data.models.Eatery
@@ -139,8 +140,8 @@ class FavoritesViewModel @Inject constructor(
                         itemName = itemName,
                         availability = if (eateriesByItem.isEmpty()) EateryStatus(
                             "Not available",
-                            Color.Red
-                        ) else EateryStatus("Available today", Color.Green),
+                            ErrorLight
+                        ) else EateryStatus("Available today", SuccessLight),
                         mealAvailability = eateriesByItem.groupBy { eatery ->
                             eatery.events?.find { event ->
                                 event.menu?.any {
@@ -150,17 +151,10 @@ class FavoritesViewModel @Inject constructor(
                         }.mapValues { mapEntry ->
                             mapEntry.value.mapNotNull { eatery -> eatery.name }
                         }.mapKeys { (key, _) ->
-                            if (key == null || key !in listOf(
-                                    "Breakfast",
-                                    "Lunch",
-                                    "Late lunch",
-                                    "Brunch",
-                                    "Dinner"
-                                )
-                            ) "Other" else key
+                            key ?: "Other"
                         }.toSortedMap { s1, s2 -> s1.toSortOrder().compareTo(s2.toSortOrder()) }
                     )
-                }.sortedByDescending { it.availability.statusColor == Color.Green }
+                }.sortedByDescending { it.availability.statusColor == SuccessLight }
 
 
                 FavoritesScreenViewState.Loaded(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/FavoritesViewModel.kt
@@ -1,6 +1,6 @@
 package com.cornellappdev.android.eatery.ui.viewmodels
 
-import ItemFavoritesCardViewState
+import com.cornellappdev.android.eatery.ui.components.details.ItemFavoritesCardViewState
 import com.cornellappdev.android.eatery.ui.theme.ErrorLight
 import com.cornellappdev.android.eatery.ui.theme.SuccessLight
 import androidx.lifecycle.ViewModel
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.time.LocalDateTime
+import java.time.LocalDate
 import javax.inject.Inject
 
 private val allEateryFilters = listOf(
@@ -106,13 +106,12 @@ class FavoritesViewModel @Inject constructor(
                     )
                 }
 
+                val today = LocalDate.now()
                 val menuItemsToEateries: Map<String, List<Eatery>> =
                     favoriteItems.associateWith { itemName ->
                         allEateries.filter { eatery ->
                             val todayEvents = eatery.events?.filter {
-                                (it.endTimestamp ?: LocalDateTime.MAX) < LocalDateTime.now()
-                                    .withHour(23)
-                                    .withMinute(59)
+                                it.startTimestamp?.toLocalDate() == today
                             }
                             todayEvents?.any { event ->
                                 event.menu?.flatMap { it.items ?: emptyList() }?.any {
@@ -142,16 +141,19 @@ class FavoritesViewModel @Inject constructor(
                             "Not available",
                             ErrorLight
                         ) else EateryStatus("Available today", SuccessLight),
-                        mealAvailability = eateriesByItem.groupBy { eatery ->
-                            eatery.events?.find { event ->
-                                event.menu?.any {
-                                    it.items?.any { menuItem -> menuItem.name == itemName } == true
-                                } == true
-                            }?.type
-                        }.mapValues { mapEntry ->
-                            mapEntry.value.mapNotNull { eatery -> eatery.name }
-                        }.mapKeys { (key, _) ->
-                            key ?: "Other"
+                        mealAvailability = buildMap<String, MutableList<String>> {
+                            eateriesByItem.forEach { eatery ->
+                                eatery.events?.filter { event ->
+                                    event.startTimestamp?.toLocalDate() == today &&
+                                    event.menu?.any { category ->
+                                        category.items?.any { menuItem -> menuItem.name == itemName } == true
+                                    } == true
+                                }?.forEach { event ->
+                                    val mealType = normalizeMealType(event.type ?: "Other")
+                                    getOrPut(mealType) { mutableListOf() }
+                                        .also { if (eatery.name != null && eatery.name !in it) it.add(eatery.name) }
+                                }
+                            }
                         }.toSortedMap { s1, s2 -> s1.toSortOrder().compareTo(s2.toSortOrder()) }
                     )
                 }.sortedByDescending { it.availability.statusColor == SuccessLight }
@@ -177,12 +179,23 @@ class FavoritesViewModel @Inject constructor(
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FavoritesUiState())
 
-    private fun String.toSortOrder(): Int = when (this) {
-        "Breakfast" -> 1
-        "Brunch" -> 2
-        "Lunch" -> 3
-        "Late lunch" -> 4
-        "Dinner" -> 5
+    private fun normalizeMealType(raw: String): String {
+        val normalized = raw.replace("_", " ").trim().lowercase()
+        return when (normalized) {
+            "late night", "late_night" -> "Late Dinner"
+            else -> normalized.split(" ").joinToString(" ") { w ->
+                w.replaceFirstChar { it.uppercase() }
+            }
+        }
+    }
+
+    private fun String.toSortOrder(): Int = when (this.lowercase()) {
+        "breakfast" -> 1
+        "brunch" -> 2
+        "lunch" -> 3
+        "late lunch" -> 4
+        "dinner" -> 5
+        "late dinner" -> 6
         else -> Int.MAX_VALUE
     }
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/UpcomingViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/UpcomingViewModel.kt
@@ -1,6 +1,8 @@
 package com.cornellappdev.android.eatery.ui.viewmodels
 
-import androidx.compose.ui.graphics.Color
+import com.cornellappdev.android.eatery.ui.theme.ErrorLight
+import com.cornellappdev.android.eatery.ui.theme.SuccessLight
+import com.cornellappdev.android.eatery.ui.theme.WarningLight
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.android.eatery.data.models.Eatery
@@ -104,9 +106,9 @@ class UpcomingViewModel @Inject constructor(
                 } ?: emptyList(),
                 name = name ?: "Unknown Eatery",
                 eateryStatus = when {
-                    isClosed() -> EateryStatus("Closed", Color.Red)
-                    isClosingSoon() -> EateryStatus("Closing Soon", Color(0xFFFFA500))
-                    else -> EateryStatus("Open", Color.Green)
+                    isClosed() -> EateryStatus("Closed", ErrorLight)
+                    isClosingSoon() -> EateryStatus("Closing Soon", WarningLight)
+                    else -> EateryStatus("Open", SuccessLight)
                 },
             )
         }


### PR DESCRIPTION
## Overview

Follow-up fixes for the dark mode PR (#222), addressing remaining visual bugs and review comments found during testing.

## Changes Made

**CompareMenus (`CompareMenusScreen.kt`)**
- Fix tab centering: `scrollOffset = -sidePaddingPx` was pushing tabs rightward; with symmetric `contentPadding = sidePadding`, `scrollOffset = 0` correctly centers each tab
- All tabs now get `accentPrimary` background so unselected tabs look like buttons, not plain text

**EateryDetailsStickyHeader (`EateryDetailsStickyHeader.kt`)**
- Category pills now correctly highlight the last visible category when scrolled to the bottom of the list (previously stuck on first-visible-only logic)
- Refactored to a single `derivedStateOf` block; removed the separate `highlightCategory` composable

**FavoritesViewModel (`FavoritesViewModel.kt`)**
- Fix "Available today" logic: use `startTimestamp.toLocalDate() == today` instead of end-time comparison, preventing past days' events from showing as available
- Normalize raw meal type strings (e.g. `Late_night` → `Late Dinner`); flatMap over all matching events per eatery so multiple meal types per location are captured

**FavoritesToggle (`FavoritesToggle.kt`)**
- Remove shadow, increase border to `1.dp` for cleaner look

**ItemFavoritesCard (`ItemFavoritesCard.kt`)**
- Use `accentPrimary` container color for dark mode contrast
- Long item names truncate with ellipsis instead of pushing star icon off-screen

**MenuCard / PaymentWidgets / FilterRow / AccountPage / Color.kt**
- `MenuCard` (Upcoming): `accentPrimary` background for card contrast in dark mode
- `PaymentWidgets`: `accentPrimary` surface color so payment icons don't disappear in dark mode
- `FilterRow`: `fillMaxWidth` on `LazyRow` for proper left-alignment
- `AccountPage`: `oppTextPrimary` tint on settings icon for both expanded and collapsed header states (icon was invisible on the blue header in dark mode)
- `AccentPrimaryDark`: lightened to `0xFF2E2E2E` for better card/background contrast

## Test Coverage

- TODO

## Next Steps (optional)

- Push unpushed commit on `Brian_DarkMode` and verify CI passes
- Visual QA in both light and dark mode on device

## Related PRs or Issues (optional)

Stacked on #222 (Brian dark mode). Closes or partially addresses #244, #245, #246, #247, #248, #249, #250, #251.

## Screenshots (optional)