### PR TITLE
Add dark mode display settings and settings access from login

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eatery/data/models/ThemePreference.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/models/ThemePreference.kt
@@ -1,0 +1,3 @@
+package com.cornellappdev.android.eatery.data.models
+
+enum class ThemePreference { LIGHT, DARK, SYSTEM }

--- a/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/data/repositories/UserPreferencesRepository.kt
@@ -2,6 +2,7 @@ package com.cornellappdev.android.eatery.data.repositories
 
 import androidx.datastore.core.DataStore
 import com.cornellappdev.android.eatery.UserPreferences
+import com.cornellappdev.android.eatery.data.models.ThemePreference
 import com.cornellappdev.android.eatery.util.decryptData
 import com.cornellappdev.android.eatery.util.encryptData
 import kotlinx.coroutines.CoroutineScope
@@ -61,6 +62,14 @@ class UserPreferencesRepository @Inject constructor(
             SharingStarted.Eagerly,
             null
         )
+    val themePreferenceFlow: Flow<ThemePreference> = userPreferencesFlow.map { prefs ->
+        when {
+            !prefs.hasIsDarkMode() -> ThemePreference.SYSTEM
+            prefs.isDarkMode -> ThemePreference.DARK
+            else -> ThemePreference.LIGHT
+        }
+    }
+
     suspend fun setDarkMode(enabled: Boolean)
     {
         userPreferencesStore.updateData { prefs -> prefs.toBuilder()

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/login/LoginPage.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/login/LoginPage.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -71,7 +72,8 @@ fun LoginPage(
     onLoginPressed: () -> Unit,
     onSuccess: (String) -> Unit,
     onBackClick: () -> Unit,
-    onModalHidden: () -> Unit
+    onModalHidden: () -> Unit,
+    onSettingsClicked: () -> Unit = {}
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var showSheet by remember { mutableStateOf(false) }
@@ -81,7 +83,7 @@ fun LoginPage(
     }
     if (!isPreview()) {
         Box {
-            LoginPageMainLayer(onBackClick, isLoading, onLoginPressed)
+            LoginPageMainLayer(onBackClick, isLoading, onLoginPressed, onSettingsClicked)
             if (showSheet) {
                 ModalBottomSheet(
                     onDismissRequest = {
@@ -111,7 +113,7 @@ fun LoginPage(
             }
         }
     } else {
-        LoginPageMainLayer(onBackClick, isLoading, onLoginPressed)
+        LoginPageMainLayer(onBackClick, isLoading, onLoginPressed, onSettingsClicked)
     }
 }
 
@@ -119,7 +121,8 @@ fun LoginPage(
 private fun LoginPageMainLayer(
     onBackClick: () -> Unit,
     loading: Boolean,
-    onLoginPressed: () -> Unit
+    onLoginPressed: () -> Unit,
+    onSettingsClicked: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -137,7 +140,7 @@ private fun LoginPageMainLayer(
                 .fillMaxWidth()
                 .padding(top = 12.dp, bottom = 2.dp)
                 .height(34.dp),
-            horizontalArrangement = Arrangement.Start,
+            horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
             IconButton(
@@ -147,6 +150,16 @@ private fun LoginPageMainLayer(
                 Image(
                     painter = painterResource(R.drawable.ic_left_chevron),
                     contentDescription = stringResource(R.string.a11y_login_back_arrow)
+                )
+            }
+            IconButton(
+                onClick = onSettingsClicked,
+                modifier = Modifier.size(24.dp, 24.dp)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.system_setting),
+                    contentDescription = stringResource(R.string.settings_title),
+                    tint = currentColors.textSecondary
                 )
             }
         }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/DisplayBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/DisplayBottomSheet.kt
@@ -1,0 +1,194 @@
+package com.cornellappdev.android.eatery.ui.components.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.DarkMode
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.WbSunny
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.cornellappdev.android.eatery.R
+import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
+import com.cornellappdev.android.eatery.ui.theme.currentColors
+import com.cornellappdev.android.eatery.util.DualModePreview
+import com.cornellappdev.android.eatery.util.EateryPreview
+
+private enum class DisplayTheme { LIGHT, DARK, SYSTEM }
+
+@Composable
+fun DisplayBottomSheet(
+    isDarkMode: Boolean?,
+    onLightSelected: () -> Unit,
+    onDarkSelected: () -> Unit,
+    onSystemSelected: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val initialTheme = when (isDarkMode) {
+        true -> DisplayTheme.DARK
+        false -> DisplayTheme.LIGHT
+        null -> DisplayTheme.SYSTEM
+    }
+    var selectedTheme by remember { mutableStateOf(initialTheme) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, top = 24.dp, bottom = 34.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.settings_display_title),
+            style = EateryBlueTypography.h4,
+            color = currentColors.textPrimary,
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
+
+        DisplayThemeRow(
+            icon = Icons.Outlined.WbSunny,
+            label = stringResource(R.string.settings_display_light),
+            selected = selectedTheme == DisplayTheme.LIGHT,
+            showTopDivider = false,
+            onClick = { selectedTheme = DisplayTheme.LIGHT }
+        )
+        DisplayThemeRow(
+            icon = Icons.Outlined.DarkMode,
+            label = stringResource(R.string.settings_display_dark),
+            selected = selectedTheme == DisplayTheme.DARK,
+            showTopDivider = true,
+            onClick = { selectedTheme = DisplayTheme.DARK }
+        )
+        DisplayThemeRow(
+            icon = Icons.Outlined.Settings,
+            label = stringResource(R.string.settings_display_system),
+            selected = selectedTheme == DisplayTheme.SYSTEM,
+            showTopDivider = true,
+            onClick = { selectedTheme = DisplayTheme.SYSTEM }
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Button(
+            onClick = {
+                when (selectedTheme) {
+                    DisplayTheme.LIGHT -> onLightSelected()
+                    DisplayTheme.DARK -> onDarkSelected()
+                    DisplayTheme.SYSTEM -> onSystemSelected()
+                }
+                onDismiss()
+            },
+            shape = RoundedCornerShape(100.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = currentColors.backgroundSecondary,
+                contentColor = currentColors.oppTextPrimary
+            )
+        ) {
+            Text(
+                text = stringResource(R.string.done),
+                style = EateryBlueTypography.h5,
+                color = currentColors.oppTextPrimary
+            )
+        }
+    }
+}
+
+@Composable
+private fun DisplayThemeRow(
+    icon: ImageVector,
+    label: String,
+    selected: Boolean,
+    showTopDivider: Boolean,
+    onClick: () -> Unit
+) {
+    if (showTopDivider) {
+        HorizontalDivider(
+            color = currentColors.borderDefault,
+            thickness = 1.dp
+        )
+    }
+    val interactionSource = remember { MutableInteractionSource() }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(63.dp)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = ripple(),
+                onClick = onClick
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+            tint = currentColors.textSecondary
+        )
+        Text(
+            text = label,
+            style = EateryBlueTypography.h5,
+            color = currentColors.textPrimary,
+            modifier = Modifier.weight(1f)
+        )
+        RadioButton(
+            selected = selected,
+            onClick = onClick,
+            colors = RadioButtonDefaults.colors(
+                selectedColor = currentColors.textPrimary,
+                unselectedColor = currentColors.borderDefault
+            )
+        )
+    }
+}
+
+@DualModePreview
+@Composable
+private fun DisplayBottomSheetLightPreview() = EateryPreview {
+    DisplayBottomSheet(
+        isDarkMode = false,
+        onLightSelected = {},
+        onDarkSelected = {},
+        onSystemSelected = {},
+        onDismiss = {}
+    )
+}
+
+@DualModePreview
+@Composable
+private fun DisplayBottomSheetDarkPreview() = EateryPreview {
+    DisplayBottomSheet(
+        isDarkMode = true,
+        onLightSelected = {},
+        onDarkSelected = {},
+        onSystemSelected = {},
+        onDismiss = {}
+    )
+}

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/DisplayBottomSheet.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/components/settings/DisplayBottomSheet.kt
@@ -34,27 +34,21 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.cornellappdev.android.eatery.R
+import com.cornellappdev.android.eatery.data.models.ThemePreference
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eatery.ui.theme.currentColors
 import com.cornellappdev.android.eatery.util.DualModePreview
 import com.cornellappdev.android.eatery.util.EateryPreview
 
-private enum class DisplayTheme { LIGHT, DARK, SYSTEM }
-
 @Composable
 fun DisplayBottomSheet(
-    isDarkMode: Boolean?,
+    themePreference: ThemePreference,
     onLightSelected: () -> Unit,
     onDarkSelected: () -> Unit,
     onSystemSelected: () -> Unit,
     onDismiss: () -> Unit
 ) {
-    val initialTheme = when (isDarkMode) {
-        true -> DisplayTheme.DARK
-        false -> DisplayTheme.LIGHT
-        null -> DisplayTheme.SYSTEM
-    }
-    var selectedTheme by remember { mutableStateOf(initialTheme) }
+    var selectedTheme by remember { mutableStateOf(themePreference) }
 
     Column(
         modifier = Modifier
@@ -71,23 +65,23 @@ fun DisplayBottomSheet(
         DisplayThemeRow(
             icon = Icons.Outlined.WbSunny,
             label = stringResource(R.string.settings_display_light),
-            selected = selectedTheme == DisplayTheme.LIGHT,
+            selected = selectedTheme == ThemePreference.LIGHT,
             showTopDivider = false,
-            onClick = { selectedTheme = DisplayTheme.LIGHT }
+            onClick = { selectedTheme = ThemePreference.LIGHT }
         )
         DisplayThemeRow(
             icon = Icons.Outlined.DarkMode,
             label = stringResource(R.string.settings_display_dark),
-            selected = selectedTheme == DisplayTheme.DARK,
+            selected = selectedTheme == ThemePreference.DARK,
             showTopDivider = true,
-            onClick = { selectedTheme = DisplayTheme.DARK }
+            onClick = { selectedTheme = ThemePreference.DARK }
         )
         DisplayThemeRow(
             icon = Icons.Outlined.Settings,
             label = stringResource(R.string.settings_display_system),
-            selected = selectedTheme == DisplayTheme.SYSTEM,
+            selected = selectedTheme == ThemePreference.SYSTEM,
             showTopDivider = true,
-            onClick = { selectedTheme = DisplayTheme.SYSTEM }
+            onClick = { selectedTheme = ThemePreference.SYSTEM }
         )
 
         Spacer(modifier = Modifier.height(12.dp))
@@ -95,9 +89,9 @@ fun DisplayBottomSheet(
         Button(
             onClick = {
                 when (selectedTheme) {
-                    DisplayTheme.LIGHT -> onLightSelected()
-                    DisplayTheme.DARK -> onDarkSelected()
-                    DisplayTheme.SYSTEM -> onSystemSelected()
+                    ThemePreference.LIGHT -> onLightSelected()
+                    ThemePreference.DARK -> onDarkSelected()
+                    ThemePreference.SYSTEM -> onSystemSelected()
                 }
                 onDismiss()
             },
@@ -173,7 +167,7 @@ private fun DisplayThemeRow(
 @Composable
 private fun DisplayBottomSheetLightPreview() = EateryPreview {
     DisplayBottomSheet(
-        isDarkMode = false,
+        themePreference = ThemePreference.LIGHT,
         onLightSelected = {},
         onDarkSelected = {},
         onSystemSelected = {},
@@ -185,7 +179,7 @@ private fun DisplayBottomSheetLightPreview() = EateryPreview {
 @Composable
 private fun DisplayBottomSheetDarkPreview() = EateryPreview {
     DisplayBottomSheet(
-        isDarkMode = true,
+        themePreference = ThemePreference.DARK,
         onLightSelected = {},
         onDarkSelected = {},
         onSystemSelected = {},

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/ProfileScreen.kt
@@ -81,7 +81,8 @@ private fun ProfileScreenContent(
                 onLoginPressed = onLoginPressed,
                 onSuccess = onSuccess,
                 onBackClick = onBackClick,
-                onModalHidden = onModalHidden
+                onModalHidden = onModalHidden,
+                onSettingsClicked = onSettingsClicked
             )
         } else {
             AccountPage(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SettingsScreen.kt
@@ -5,10 +5,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
@@ -17,6 +20,7 @@ import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.Gavel
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.StarOutline
+import androidx.compose.material.icons.outlined.WbSunny
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -25,6 +29,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -38,12 +43,14 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.cornellappdev.android.eatery.R
 import com.cornellappdev.android.eatery.ui.components.settings.AppIconBottomSheet
+import com.cornellappdev.android.eatery.ui.components.settings.DisplayBottomSheet
 import com.cornellappdev.android.eatery.ui.components.settings.SettingsLineSeparator
 import com.cornellappdev.android.eatery.ui.components.settings.SettingsOption
 import com.cornellappdev.android.eatery.ui.navigation.Routes
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eatery.ui.theme.currentColors
 import com.cornellappdev.android.eatery.ui.viewmodels.SettingsViewModel
+import com.cornellappdev.android.eatery.ui.viewmodels.ThemeViewModel
 import com.cornellappdev.android.eatery.util.DualModePreview
 import com.cornellappdev.android.eatery.util.EateryPreview
 import kotlinx.coroutines.launch
@@ -52,10 +59,18 @@ import kotlinx.coroutines.launch
 @Composable
 fun SettingsScreen(
     settingsViewModel: SettingsViewModel = hiltViewModel(),
+    themeViewModel: ThemeViewModel = hiltViewModel(),
     destinations: HashMap<Routes, () -> Unit>
 ) {
+    val isDarkMode by themeViewModel.isDarkMode.collectAsState()
+    val isLoggedIn by themeViewModel.isLoggedIn.collectAsState()
     SettingsScreenContent(
         destinations = destinations,
+        isDarkMode = isDarkMode,
+        isLoggedIn = isLoggedIn,
+        onLightSelected = themeViewModel::toggleLightMode,
+        onDarkSelected = themeViewModel::toggleDarkMode,
+        onSystemSelected = themeViewModel::toggleSystemMode,
         onLogout = {
             settingsViewModel.onLogout(onDone = {
                 destinations[Routes.PROFILE]?.invoke()
@@ -68,6 +83,11 @@ fun SettingsScreen(
 @Composable
 private fun SettingsScreenContent(
     destinations: Map<Routes, () -> Unit>,
+    isDarkMode: Boolean?,
+    isLoggedIn: Boolean,
+    onLightSelected: () -> Unit,
+    onDarkSelected: () -> Unit,
+    onSystemSelected: () -> Unit,
     onLogout: () -> Unit,
 ) {
     // To sign out, setIsLoggedIn to false and transition back to profileView with autoLogin false
@@ -76,6 +96,7 @@ private fun SettingsScreenContent(
         skipPartiallyExpanded = true,
     )
     var showAppIconSheet by remember { mutableStateOf(false) }
+    var showDisplaySheet by remember { mutableStateOf(false) }
 
     if (showAppIconSheet) {
         ModalBottomSheet(
@@ -100,10 +121,33 @@ private fun SettingsScreenContent(
         }
     }
 
+    if (showDisplaySheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showDisplaySheet = false },
+            containerColor = currentColors.backgroundDefault,
+            contentColor = currentColors.textPrimary,
+            shape = RoundedCornerShape(
+                bottomStart = 0.dp,
+                bottomEnd = 0.dp,
+                topStart = 12.dp,
+                topEnd = 12.dp
+            )
+        ) {
+            DisplayBottomSheet(
+                isDarkMode = isDarkMode,
+                onLightSelected = onLightSelected,
+                onDarkSelected = onDarkSelected,
+                onSystemSelected = onSystemSelected,
+                onDismiss = { showDisplaySheet = false }
+            )
+        }
+    }
+
     Column(
         modifier = Modifier
             .background(color = currentColors.backgroundDefault)
             .fillMaxWidth()
+            .fillMaxHeight()
             .padding(horizontal = 16.dp)
             .then(Modifier.statusBarsPadding())
     ) {
@@ -113,6 +157,11 @@ private fun SettingsScreenContent(
             style = EateryBlueTypography.h2,
             modifier = Modifier.padding(top = 7.dp, bottom = 7.dp)
         )
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+        ) {
         SettingsOption(
             leadingIcon = {
                 Icon(
@@ -207,6 +256,27 @@ private fun SettingsScreenContent(
         SettingsOption(
             leadingIcon = {
                 Icon(
+                    imageVector = Icons.Outlined.WbSunny,
+                    contentDescription = stringResource(R.string.settings_display_title),
+                    tint = currentColors.textSecondary,
+                    modifier = Modifier.size(24.dp)
+                )
+            },
+            trailingIcon = {
+                Icon(
+                    imageVector = Icons.Outlined.ChevronRight,
+                    contentDescription = null,
+                    tint = currentColors.backgroundSecondary,
+                )
+            },
+            title = stringResource(R.string.settings_display_title),
+            description = stringResource(R.string.settings_display_description),
+            onClick = { showDisplaySheet = true }
+        )
+        SettingsLineSeparator()
+        SettingsOption(
+            leadingIcon = {
+                Icon(
                     imageVector = Icons.Outlined.Lock,
                     contentDescription = stringResource(R.string.settings_privacy_title),
                     tint = currentColors.textSecondary,
@@ -273,35 +343,35 @@ private fun SettingsScreenContent(
             }
         )
 
-        Spacer(modifier = Modifier.weight(1f))
+        } // end scrollable Column
 
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 34.dp),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Button(
-                onClick = {
-                    onLogout()
-                },
-                shape = RoundedCornerShape(25.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = currentColors.accentPrimary,
-                    contentColor = currentColors.textPrimary
-                )
+        if (isLoggedIn) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.Logout,
-                    contentDescription = Icons.AutoMirrored.Filled.Logout.name,
-                )
-                Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
-                Text(
-                    text = stringResource(R.string.settings_logout),
-                    style = EateryBlueTypography.button,
-                    color = currentColors.textPrimary
-                )
+                Button(
+                    onClick = { onLogout() },
+                    shape = RoundedCornerShape(25.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = currentColors.accentPrimary,
+                        contentColor = currentColors.textPrimary
+                    )
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Logout,
+                        contentDescription = Icons.AutoMirrored.Filled.Logout.name,
+                    )
+                    Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
+                    Text(
+                        text = stringResource(R.string.settings_logout),
+                        style = EateryBlueTypography.button,
+                        color = currentColors.textPrimary
+                    )
+                }
             }
         }
     }
@@ -323,6 +393,11 @@ private fun previewDestinations(): Map<Routes, () -> Unit> = hashMapOf(
 private fun SettingsScreenPreview() = EateryPreview {
     SettingsScreenContent(
         destinations = previewDestinations(),
+        isDarkMode = null,
+        isLoggedIn = true,
+        onLightSelected = {},
+        onDarkSelected = {},
+        onSystemSelected = {},
         onLogout = {}
     )
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SettingsScreen.kt
@@ -49,6 +49,7 @@ import com.cornellappdev.android.eatery.ui.components.settings.SettingsOption
 import com.cornellappdev.android.eatery.ui.navigation.Routes
 import com.cornellappdev.android.eatery.ui.theme.EateryBlueTypography
 import com.cornellappdev.android.eatery.ui.theme.currentColors
+import com.cornellappdev.android.eatery.data.models.ThemePreference
 import com.cornellappdev.android.eatery.ui.viewmodels.SettingsViewModel
 import com.cornellappdev.android.eatery.ui.viewmodels.ThemeViewModel
 import com.cornellappdev.android.eatery.util.DualModePreview
@@ -62,11 +63,11 @@ fun SettingsScreen(
     themeViewModel: ThemeViewModel = hiltViewModel(),
     destinations: HashMap<Routes, () -> Unit>
 ) {
-    val isDarkMode by themeViewModel.isDarkMode.collectAsStateWithLifecycle()
-    val isLoggedIn by themeViewModel.isLoggedIn.collectAsStateWithLifecycle()
+    val themePreference by themeViewModel.themePreference.collectAsStateWithLifecycle()
+    val isLoggedIn by settingsViewModel.isLoggedIn.collectAsStateWithLifecycle()
     SettingsScreenContent(
         destinations = destinations,
-        isDarkMode = isDarkMode,
+        themePreference = themePreference,
         isLoggedIn = isLoggedIn,
         onLightSelected = themeViewModel::toggleLightMode,
         onDarkSelected = themeViewModel::toggleDarkMode,
@@ -83,7 +84,7 @@ fun SettingsScreen(
 @Composable
 private fun SettingsScreenContent(
     destinations: Map<Routes, () -> Unit>,
-    isDarkMode: Boolean?,
+    themePreference: ThemePreference,
     isLoggedIn: Boolean,
     onLightSelected: () -> Unit,
     onDarkSelected: () -> Unit,
@@ -134,7 +135,7 @@ private fun SettingsScreenContent(
             )
         ) {
             DisplayBottomSheet(
-                isDarkMode = isDarkMode,
+                themePreference = themePreference,
                 onLightSelected = onLightSelected,
                 onDarkSelected = onDarkSelected,
                 onSystemSelected = onSystemSelected,
@@ -393,7 +394,7 @@ private fun previewDestinations(): Map<Routes, () -> Unit> = hashMapOf(
 private fun SettingsScreenPreview() = EateryPreview {
     SettingsScreenContent(
         destinations = previewDestinations(),
-        isDarkMode = null,
+        themePreference = ThemePreference.SYSTEM,
         isLoggedIn = true,
         onLightSelected = {},
         onDarkSelected = {},

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/SettingsScreen.kt
@@ -29,8 +29,8 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -62,8 +62,8 @@ fun SettingsScreen(
     themeViewModel: ThemeViewModel = hiltViewModel(),
     destinations: HashMap<Routes, () -> Unit>
 ) {
-    val isDarkMode by themeViewModel.isDarkMode.collectAsState()
-    val isLoggedIn by themeViewModel.isLoggedIn.collectAsState()
+    val isDarkMode by themeViewModel.isDarkMode.collectAsStateWithLifecycle()
+    val isLoggedIn by themeViewModel.isLoggedIn.collectAsStateWithLifecycle()
     SettingsScreenContent(
         destinations = destinations,
         isDarkMode = isDarkMode,
@@ -363,7 +363,7 @@ private fun SettingsScreenContent(
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.Logout,
-                        contentDescription = Icons.AutoMirrored.Filled.Logout.name,
+                        contentDescription = null,
                     )
                     Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
                     Text(

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/UpcomingMenuScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/screens/UpcomingMenuScreen.kt
@@ -376,6 +376,9 @@ private fun UpcomingLazyColumn(
         item {
             filterRow()
         }
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
         content()
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Theme.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/theme/Theme.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.cornellappdev.android.eatery.data.models.ThemePreference
 import com.cornellappdev.android.eatery.ui.viewmodels.ThemeViewModel
 
 val LocalColorMode = staticCompositionLocalOf { ColorTheme.lightMode }
@@ -16,7 +17,6 @@ fun AppColorTheme(
     colorMode: ColorMode,
     content: @Composable () -> Unit
 ) {
-
     CompositionLocalProvider(LocalColorMode provides colorMode) {
         content()
     }
@@ -27,7 +27,10 @@ val currentColors: ColorMode
 
 @Composable
 fun rememberResolvedDarkMode(themeViewModel: ThemeViewModel = hiltViewModel()): Boolean {
-    val isDarkMode by themeViewModel.isDarkMode.collectAsState()
-    return isDarkMode ?: isSystemInDarkTheme()
+    val themePreference by themeViewModel.themePreference.collectAsState()
+    return when (themePreference) {
+        ThemePreference.DARK -> true
+        ThemePreference.LIGHT -> false
+        ThemePreference.SYSTEM -> isSystemInDarkTheme()
+    }
 }
-

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/SettingsViewModel.kt
@@ -2,15 +2,26 @@ package com.cornellappdev.android.eatery.ui.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.cornellappdev.android.eatery.data.repositories.UserPreferencesRepository
 import com.cornellappdev.android.eatery.data.repositories.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val userRepository: UserRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
 ) : ViewModel() {
+
+    val isLoggedIn: StateFlow<Boolean> = userPreferencesRepository.isLoggedInFlow.stateIn(
+        viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = false
+    )
 
     fun onLogout(onDone: () -> Unit = {}) {
         viewModelScope.launch {
@@ -19,4 +30,3 @@ class SettingsViewModel @Inject constructor(
         }
     }
 }
-

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/ThemeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/ThemeViewModel.kt
@@ -14,10 +14,17 @@ import javax.inject.Inject
 class ThemeViewModel @Inject constructor(
     private val repository: UserPreferencesRepository): ViewModel()
 {
-    val isDarkMode : StateFlow<Boolean?> = repository.isDarkModeFlow.stateIn(
+    val isDarkMode: StateFlow<Boolean?> = repository.isDarkModeFlow.stateIn(
         viewModelScope,
         started = SharingStarted.Eagerly,
-        initialValue = null)
+        initialValue = null
+    )
+
+    val isLoggedIn: StateFlow<Boolean> = repository.isLoggedInFlow.stateIn(
+        viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = false
+    )
 
     fun toggleDarkMode()
     {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/ThemeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ui/viewmodels/ThemeViewModel.kt
@@ -2,6 +2,7 @@ package com.cornellappdev.android.eatery.ui.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.cornellappdev.android.eatery.data.models.ThemePreference
 import com.cornellappdev.android.eatery.data.repositories.UserPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
@@ -12,34 +13,24 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ThemeViewModel @Inject constructor(
-    private val repository: UserPreferencesRepository): ViewModel()
-{
-    val isDarkMode: StateFlow<Boolean?> = repository.isDarkModeFlow.stateIn(
+    private val repository: UserPreferencesRepository
+) : ViewModel() {
+
+    val themePreference: StateFlow<ThemePreference> = repository.themePreferenceFlow.stateIn(
         viewModelScope,
         started = SharingStarted.Eagerly,
-        initialValue = null
+        initialValue = ThemePreference.SYSTEM
     )
 
-    val isLoggedIn: StateFlow<Boolean> = repository.isLoggedInFlow.stateIn(
-        viewModelScope,
-        started = SharingStarted.Eagerly,
-        initialValue = false
-    )
-
-    fun toggleDarkMode()
-    {
-        viewModelScope.launch { repository.setDarkMode(true)}
-    }
-    fun toggleLightMode()
-    {
-        viewModelScope.launch { repository.setDarkMode(false)}
+    fun toggleDarkMode() {
+        viewModelScope.launch { repository.setDarkMode(true) }
     }
 
-    fun toggleSystemMode()
-    {
-        viewModelScope.launch {repository.setSystemMode()}
+    fun toggleLightMode() {
+        viewModelScope.launch { repository.setDarkMode(false) }
     }
 
+    fun toggleSystemMode() {
+        viewModelScope.launch { repository.setSystemMode() }
+    }
 }
-
-

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,11 @@
     <string name="settings_favorites_description">Manage your favorite eateries and items</string>
     <string name="settings_notifications_title">Notifications</string>
     <string name="settings_notifications_description">Manage item and promotional notifications</string>
+    <string name="settings_display_title">Display</string>
+    <string name="settings_display_description">Choose a light or dark theme</string>
+    <string name="settings_display_light">Light</string>
+    <string name="settings_display_dark">Dark</string>
+    <string name="settings_display_system">Device Theme</string>
     <string name="settings_privacy_title">Privacy</string>
     <string name="settings_privacy_description">Manage permissions and analytics</string>
     <string name="settings_legal_title">Legal</string>


### PR DESCRIPTION
## Overview

Adds a **Display** settings option so users can choose Light, Dark, or Device Theme for the app's appearance. Also adds a settings gear icon to the login page so unauthenticated users can reach Settings without logging in first. Added spacing in upcoming menus between filter row and content.

## Changes Made

**New file — `DisplayBottomSheet.kt`**
- Modal bottom sheet with three radio-button options: Light (sun icon), Dark (moon icon), Device Theme (gear icon)
- Local selection state committed only when the user taps "Done"
- Fully themed via `currentColors` and `EateryBlueTypography`; supports light and dark preview via `@DualModePreview`

**`SettingsScreen.kt`**
- Injects `ThemeViewModel` to collect `isDarkMode` and `isLoggedIn` state
- New "Display" row (sun icon, "Choose a light or dark theme") inserted between Notifications and Privacy; opens `DisplayBottomSheet`
- Settings list wrapped in a scrollable inner `Column` so all items remain accessible on smaller screens
- Logout button now pinned at the bottom and conditionally hidden when the user is not logged in

**`ThemeViewModel.kt`**
- Exposes `isLoggedIn: StateFlow<Boolean>` from `UserPreferencesRepository.isLoggedInFlow`

**`LoginPage.kt`**
- Adds `onSettingsClicked` parameter (default no-op for backward compatibility)
- Settings gear icon (`system_setting` drawable) added to the top-right of the nav row via `Arrangement.SpaceBetween`

**`ProfileScreen.kt`**
- Passes `onSettingsClicked` through to `LoginPage` so navigation wires up correctly

**`UpcomingMenusScreen.kt`**
- Adds spacer between filter row and content

**`strings.xml`**
- Added `settings_display_title`, `settings_display_description`, `settings_display_light`, `settings_display_dark`, `settings_display_system`

## Test Coverage

- TODO: Manual test — tap Display → sheet opens; select each option → theme updates; tap Done → sheet dismisses; kill/relaunch → preference persists via DataStore
- TODO: Manual test — toggle system dark mode with Device Theme selected → app follows system setting
- TODO: Manual test — log out → logout button disappears from Settings; navigate to Profile tab → gear icon visible on login page; tap → Settings screen opens

## Next Steps (optional)

TODO

## Related PRs or Issues (optional)
- Resolves #253.

## Screenshots (optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a settings button on the login page.
  * New Display theme selector (Light / Dark / System) via a bottom sheet in Settings.
  * Theme preference model and app-wide theme setting support.

* **Improvements**
  * Settings screen wired to show/hide logout based on login state and open the Display sheet.
  * Profile screen routes settings clicks into the app.

* **Other**
  * Added user-facing strings and minor layout spacing tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->